### PR TITLE
Version 2.37.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+# [2.37.11] - 2024-10-01
+
+- [Common] matrix-rich-text-editor is being forked by Element at https://github.com/element-hq/matrix-rich-text-editor. Contributions are licensed to Element under a CLA and made available under an AGPLv3.0 license.
+  You can read more about this here:
+  - https://matrix.org/blog/2024/08/heart-of-matrix/
+  - https://element.io/blog/sustainable-licensing-at-element-with-agpl/
+- [Web] The matrix-wysiwyg npm package will now be published at https://www.npmjs.com/package/@vector-im/matrix-wysiwyg
+
 # [2.37.9] - 2024-08-28
 - [Rust] Escape text passed to `ComposerModel::set_link_with_text` and `insert_mention*` methods of the WASM bindings.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1391,7 +1391,7 @@ dependencies = [
 
 [[package]]
 name = "uniffi-wysiwyg-composer"
-version = "2.37.10"
+version = "2.37.11"
 dependencies = [
  "html-escape",
  "matrix_mentions",
@@ -1852,7 +1852,7 @@ dependencies = [
 
 [[package]]
 name = "wysiwyg"
-version = "2.37.10"
+version = "2.37.11"
 dependencies = [
  "cfg-if",
  "email_address",
@@ -1876,7 +1876,7 @@ dependencies = [
 
 [[package]]
 name = "wysiwyg-wasm"
-version = "2.37.10"
+version = "2.37.11"
 dependencies = [
  "console_error_panic_hook",
  "html-escape",

--- a/bindings/wysiwyg-ffi/Cargo.toml
+++ b/bindings/wysiwyg-ffi/Cargo.toml
@@ -7,7 +7,7 @@ description = "Swift and Kotlin bindings for wysiwyg-rust"
 keywords = ["matrix", "chat", "messaging", "composer", "wysiwyg"]
 license = "AGPL-3.0"
 name = "uniffi-wysiwyg-composer"
-version = "2.37.10"
+version = "2.37.11"
 rust-version = { workspace = true }
 
 [features]

--- a/bindings/wysiwyg-wasm/Cargo.toml
+++ b/bindings/wysiwyg-wasm/Cargo.toml
@@ -7,7 +7,7 @@ description = "WASM bindings for wysiwyg-rust"
 keywords = ["matrix", "chat", "messaging", "composer", "wysiwyg"]
 license = "AGPL-3.0"
 name = "wysiwyg-wasm"
-version = "2.37.10"
+version = "2.37.11"
 rust-version = { workspace = true }
 
 [package.metadata.wasm-pack.profile.profiling]

--- a/bindings/wysiwyg-wasm/package-lock.json
+++ b/bindings/wysiwyg-wasm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wysiwyg-wasm",
-  "version": "2.37.10",
+  "version": "2.37.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wysiwyg-wasm",
-      "version": "2.37.10",
+      "version": "2.37.11",
       "license": "AGPL-3.0",
       "devDependencies": {
         "jest": "^28.1.0",

--- a/bindings/wysiwyg-wasm/package.json
+++ b/bindings/wysiwyg-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wysiwyg-wasm",
-  "version": "2.37.10",
+  "version": "2.37.11",
   "homepage": "https://gitlab.com/andybalaam/wysiwyg-rust",
   "description": "WASM bindings for wysiwyg-rust",
   "license": "AGPL-3.0",

--- a/crates/wysiwyg/Cargo.toml
+++ b/crates/wysiwyg/Cargo.toml
@@ -7,7 +7,7 @@ description = "Model code to power a rich text editor for Matrix"
 keywords = ["matrix", "chat", "messaging", "composer", "wysiwyg"]
 license = "AGPL-3.0"
 name = "wysiwyg"
-version = "2.37.10"
+version = "2.37.11"
 rust-version = { workspace = true }
 
 [features]

--- a/platforms/android/gradle.properties
+++ b/platforms/android/gradle.properties
@@ -27,7 +27,7 @@ RELEASE_SIGNING_ENABLED=true
 
 GROUP=io.element.android
 # POM_ARTIFACT_ID is configured in each module's gradle.properties
-VERSION_NAME=2.37.10
+VERSION_NAME=2.37.11
 
 POM_NAME=Matrix Rich Text Editor
 POM_DESCRIPTION=Cross-platform rich text editor that generates HTML output.

--- a/platforms/web/package.json
+++ b/platforms/web/package.json
@@ -1,9 +1,9 @@
 {
-    "name": "@matrix-org/matrix-wysiwyg",
-    "version": "2.37.10",
+    "name": "@vector-im/matrix-wysiwyg",
+    "version": "2.37.11",
     "type": "module",
-    "description": "Wysiwyg composer for matrix.org using React",
-    "author": "matrix.org",
+    "description": "Wysiwyg composer for Element Web using React",
+    "author": "New Vector Ltd.",
     "repository": {
         "type": "git",
         "url": "https://github.com/element-hq/matrix-rich-text-editor"


### PR DESCRIPTION
# [2.37.11] - 2024-10-01

- [Common] matrix-rich-text-editor is being forked by Element at https://github.com/element-hq/matrix-rich-text-editor. Contributions are licensed to Element under a CLA and made available under an AGPLv3.0 license.
  You can read more about this here:
  - https://matrix.org/blog/2024/08/heart-of-matrix/
  - https://element.io/blog/sustainable-licensing-at-element-with-agpl/
- [Web] The matrix-wysiwyg npm package will now be published at https://www.npmjs.com/package/@vector-im/matrix-wysiwyg