### PR TITLE
Use the new publish & release task to release the Android library

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,12 +80,7 @@ jobs:
         uses: gradle/gradle-build-action@v3
         with:
           build-root-directory: platforms/android
-          arguments: publishAllPublicationsToMavenCentral
-      - name: 🚀 Close staging repo and release version
-        uses: gradle/gradle-build-action@v3
-        with:
-          build-root-directory: platforms/android
-          arguments: closeAndReleaseRepository
+          arguments: publishAndReleaseToMavenCentral
 
   npm:
     name: Publish to npm


### PR DESCRIPTION
It seems to be the only thing missing for having a working publishing flow.