### PR TITLE
[Android] Fix: split editor and message mode in html parsing

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -31,6 +31,14 @@ jobs:
       matrix:
         api-level: [29]
     steps:
+      - name: Set env vars
+        run: |
+          echo "ANDROID_NDK_TOOLCHAIN_DIR=$ANDROID_NDK_HOME/toolchains" >> $GITHUB_ENV
+          export ANDROID_NDK_TOOLCHAIN_DIR=$ANDROID_NDK_HOME/toolchains
+          echo "Toolchain dir: $ANDROID_NDK_TOOLCHAIN_DIR."
+          echo "Contents:"
+          find $ANDROID_NDK_TOOLCHAIN_DIR -maxdepth 1
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -50,8 +58,6 @@ jobs:
 
       - name: Setup Gradle & Build test cases
         uses: gradle/gradle-build-action@v3
-        env:
-          ANDROID_NDK_TOOLCHAIN_DIR: ${{ env.ANDROID_NDK_HOME }}/toolchains
         with:
           build-root-directory: platforms/android
           cache-read-only: false

--- a/platforms/android/example-compose/src/main/java/io/element/wysiwyg/compose/MainActivity.kt
+++ b/platforms/android/example-compose/src/main/java/io/element/wysiwyg/compose/MainActivity.kt
@@ -70,6 +70,7 @@ class MainActivity : ComponentActivity() {
                     StyledHtmlConverter(
                         context = context,
                         mentionDisplayHandler = mentionDisplayHandler,
+                        isEditor = false,
                         isMention = mentionDetector?.let { detector ->
                             { _, url ->
                                 detector.isMention(url)

--- a/platforms/android/example-view/src/main/java/io/element/android/wysiwyg/poc/RichTextEditor.kt
+++ b/platforms/android/example-view/src/main/java/io/element/android/wysiwyg/poc/RichTextEditor.kt
@@ -177,9 +177,9 @@ class RichTextEditor : LinearLayout {
                 val rooms = listOf("matrix", "element").map(Mention::Room)
                 val everyone = Mention.NotifyEveryone
                 val names = when (menuAction.suggestionPattern.key) {
-                    PatternKey.AT -> people + everyone
-                    PatternKey.HASH -> rooms
-                    PatternKey.SLASH ->
+                    PatternKey.At -> people + everyone
+                    PatternKey.Hash -> rooms
+                    PatternKey.Slash, is PatternKey.Custom ->
                         emptyList() // TODO
                 }
                 val suggestions = names

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/StyledHtmlConverter.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/StyledHtmlConverter.kt
@@ -20,6 +20,7 @@ import timber.log.Timber
 class StyledHtmlConverter(
     private val context: Context,
     private val mentionDisplayHandler: MentionDisplayHandler?,
+    private val isEditor: Boolean,
     private val isMention: ((text: String, url: String) -> Boolean)?,
 ) : HtmlConverter {
 
@@ -31,6 +32,7 @@ class StyledHtmlConverter(
             context = context,
             styleConfig = style.toStyleConfig(context),
             mentionDisplayHandler = mentionDisplayHandler,
+            isEditor = isEditor,
             isMention = isMention,
         )
     }

--- a/platforms/android/library/build.gradle
+++ b/platforms/android/library/build.gradle
@@ -20,6 +20,7 @@ cargo {
     targets = ["arm", "x86", "x86_64", "arm64"]
     targetIncludes = ["libuniffi_wysiwyg_composer.so"]
     targetDirectory = '../../../target'
+    prebuiltToolchains = true
 }
 
 android {
@@ -69,12 +70,12 @@ android {
         jacocoVersion = "0.8.8"
     }
 
-    ndkVersion = "27.1.12297006"
-
     packagingOptions {
         resources.excludes += 'META-INF/LICENSE.md'
         resources.excludes += 'META-INF/LICENSE-notice.md'
     }
+
+    ndkVersion getNdkVersionAsWorkaround()
 }
 
 kotlin {
@@ -143,3 +144,10 @@ tasks.withType(Test) {
     jacoco.excludes = ['jdk.internal.*']
 }
 
+// Workaround for https://github.com/mozilla/rust-android-gradle/issues/46
+// This looks for the NDK path like: '/some/path/to/sdk/ndk/23.0.7599858'
+// and takes the last path component, which should be the version number
+def getNdkVersionAsWorkaround() {
+    def ndkDirectory = new File(android.sdkDirectory, "ndk")
+    return ndkDirectory.list().sort().last().split(PATH_SEPARATOR).last()
+}

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnectionIntegrationTest.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnectionIntegrationTest.kt
@@ -37,6 +37,7 @@ class InterceptInputConnectionIntegrationTest {
         it.htmlConverter = HtmlConverter.Factory.create(
             context = app,
             styleConfig = styleConfig,
+            isEditor = true,
             mentionDisplayHandler = null,
         )
     }

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditText.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditText.kt
@@ -94,6 +94,7 @@ class EditorEditText : AppCompatEditText {
             context = context.applicationContext,
             styleConfig = styleConfig,
             mentionDisplayHandler = mentionDisplayHandler,
+            isEditor = true,
         )
     }
 

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorStyledTextView.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorStyledTextView.kt
@@ -216,6 +216,7 @@ open class EditorStyledTextView : AppCompatTextView {
         return HtmlConverter.Factory.create(context = context,
             styleConfig = styleConfig,
             mentionDisplayHandler = mentionDisplayHandler,
+            isEditor = false,
             isMention = mentionDetector?.let { detector ->
                 { _, url ->
                     detector.isMention(url)

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlConverter.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlConverter.kt
@@ -23,6 +23,7 @@ interface HtmlConverter {
             context: Context,
             styleConfig: StyleConfig,
             mentionDisplayHandler: MentionDisplayHandler?,
+            isEditor: Boolean,
             isMention: ((text: String, url: String) -> Boolean)? = null,
         ): HtmlConverter {
             val resourcesProvider = AndroidResourcesHelper(context)
@@ -32,6 +33,7 @@ interface HtmlConverter {
                     html = html,
                     styleConfig = styleConfig,
                     mentionDisplayHandler = mentionDisplayHandler,
+                    isEditor = isEditor,
                     isMention = isMention,
                 )
             })

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToSpansParser.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToSpansParser.kt
@@ -54,6 +54,7 @@ internal class HtmlToSpansParser(
     private val html: String,
     private val styleConfig: StyleConfig,
     private val mentionDisplayHandler: MentionDisplayHandler?,
+    private val isEditor: Boolean,
     private val isMention: ((text: String, url: String) -> Boolean)? = null,
 ) {
     private val safeList = Safelist()
@@ -301,6 +302,10 @@ internal class HtmlToSpansParser(
     private fun SpannableStringBuilder.addLeadingLineBreakForBlockNode(element: Element) {
         if (element.isBlock && element.previousElementSibling()?.takeIf { it.tagName() != "br" } != null) {
             append('\n')
+            // If we're not in editor mode, add another line break to separate blocks
+            if (!isEditor) {
+                append('\n')
+            }
         }
     }
 

--- a/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/utils/HtmlToSpansParserTest.kt
+++ b/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/utils/HtmlToSpansParserTest.kt
@@ -180,8 +180,43 @@ class HtmlToSpansParserTest {
         )
     }
 
+    @Test
+    fun testParagraphsAreTranslatedToSingleLineBreakWhenEditorModeIsEnabled() {
+        val html = """
+            <p>Hello</p><p>World!</p>
+        """.trimIndent()
+        val spanned = convertHtml(html, isEditor = true, mentionDisplayHandler = object : MentionDisplayHandler {
+            override fun resolveAtRoomMentionDisplay(): TextDisplay =
+                TextDisplay.Pill
+
+            override fun resolveMentionDisplay(text: String, url: String): TextDisplay =
+                TextDisplay.Pill
+        })
+        assertThat(
+            spanned.toString(), equalTo("Hello\nWorld!")
+        )
+    }
+
+    @Test
+    fun testParagraphsAreTranslatedToDoubleLineBreakWhenEditorModeIsDisabled() {
+        val html = """
+            <p>Hello</p><p>World!</p>
+        """.trimIndent()
+        val spanned = convertHtml(html, isEditor = false, mentionDisplayHandler = object : MentionDisplayHandler {
+            override fun resolveAtRoomMentionDisplay(): TextDisplay =
+                TextDisplay.Pill
+
+            override fun resolveMentionDisplay(text: String, url: String): TextDisplay =
+                TextDisplay.Pill
+        })
+        assertThat(
+            spanned.toString(), equalTo("Hello\n\nWorld!")
+        )
+    }
+
     private fun convertHtml(
         html: String,
+        isEditor: Boolean = true,
         mentionDisplayHandler: MentionDisplayHandler? = null,
     ): Spanned {
         val app = RuntimeEnvironment.getApplication()
@@ -191,6 +226,7 @@ class HtmlToSpansParserTest {
             html = html,
             styleConfig = styleConfig,
             mentionDisplayHandler = mentionDisplayHandler,
+            isEditor = isEditor,
             isMention = { _, url ->
                 url.startsWith("https://matrix.to/#/@")
             }


### PR DESCRIPTION
When we translate HTML to spans in Android, we want the paragraph tags (`<p>`) to translate to a double line break ( `\n\n`) since Android doesn't have support for inter-paragraph spacing and we need to simulate this by using this workaround.

However, this is not something we can support in the actual editor since it would break the index matching, add new points in the text that can be selected, removed, etc. and would make it crash.

So we end up having to differentiate between HTML parsing for the editor and HTML parsing to display in messages to support this change. Also, this means the rendering on the editor and what's rendered later for the sent message might not match 1:1 as until now.
