### PR TITLE
Version 2.37.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# [2.37.14]
+- [Android] Have separate modes for parsing HTML for 'editor mode' and 'message mode' using `isEditor: Boolean` parameter.
+- [Android] Try auto-selecting the latest NDK version available instead of using a hardcoded one.
+- [Web] Update example app to use the new npm package.
+
 # [2.37.13] - 2024-10-04
 - [Android] Make `RichTextEditorStyle` and other data classes' constructors public to match their `copy` methods in Kotlin 2.0. This would cause build errors on Kotlin 2.1.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1391,7 +1391,7 @@ dependencies = [
 
 [[package]]
 name = "uniffi-wysiwyg-composer"
-version = "2.37.13"
+version = "2.37.14"
 dependencies = [
  "html-escape",
  "matrix_mentions",
@@ -1852,7 +1852,7 @@ dependencies = [
 
 [[package]]
 name = "wysiwyg"
-version = "2.37.13"
+version = "2.37.14"
 dependencies = [
  "cfg-if",
  "email_address",
@@ -1876,7 +1876,7 @@ dependencies = [
 
 [[package]]
 name = "wysiwyg-wasm"
-version = "2.37.13"
+version = "2.37.14"
 dependencies = [
  "console_error_panic_hook",
  "html-escape",

--- a/bindings/wysiwyg-ffi/Cargo.toml
+++ b/bindings/wysiwyg-ffi/Cargo.toml
@@ -7,7 +7,7 @@ description = "Swift and Kotlin bindings for wysiwyg-rust"
 keywords = ["matrix", "chat", "messaging", "composer", "wysiwyg"]
 license = "AGPL-3.0"
 name = "uniffi-wysiwyg-composer"
-version = "2.37.13"
+version = "2.37.14"
 rust-version = { workspace = true }
 
 [features]

--- a/bindings/wysiwyg-wasm/Cargo.toml
+++ b/bindings/wysiwyg-wasm/Cargo.toml
@@ -7,7 +7,7 @@ description = "WASM bindings for wysiwyg-rust"
 keywords = ["matrix", "chat", "messaging", "composer", "wysiwyg"]
 license = "AGPL-3.0"
 name = "wysiwyg-wasm"
-version = "2.37.13"
+version = "2.37.14"
 rust-version = { workspace = true }
 
 [package.metadata.wasm-pack.profile.profiling]

--- a/bindings/wysiwyg-wasm/package-lock.json
+++ b/bindings/wysiwyg-wasm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wysiwyg-wasm",
-  "version": "2.37.13",
+  "version": "2.37.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wysiwyg-wasm",
-      "version": "2.37.13",
+      "version": "2.37.14",
       "license": "AGPL-3.0",
       "devDependencies": {
         "jest": "^28.1.0",

--- a/bindings/wysiwyg-wasm/package.json
+++ b/bindings/wysiwyg-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wysiwyg-wasm",
-  "version": "2.37.13",
+  "version": "2.37.14",
   "homepage": "https://gitlab.com/andybalaam/wysiwyg-rust",
   "description": "WASM bindings for wysiwyg-rust",
   "license": "AGPL-3.0",

--- a/crates/wysiwyg/Cargo.toml
+++ b/crates/wysiwyg/Cargo.toml
@@ -7,7 +7,7 @@ description = "Model code to power a rich text editor for Matrix"
 keywords = ["matrix", "chat", "messaging", "composer", "wysiwyg"]
 license = "AGPL-3.0"
 name = "wysiwyg"
-version = "2.37.13"
+version = "2.37.14"
 rust-version = { workspace = true }
 
 [features]

--- a/platforms/android/gradle.properties
+++ b/platforms/android/gradle.properties
@@ -27,7 +27,7 @@ RELEASE_SIGNING_ENABLED=true
 
 GROUP=io.element.android
 # POM_ARTIFACT_ID is configured in each module's gradle.properties
-VERSION_NAME=2.37.13
+VERSION_NAME=2.37.14
 
 POM_NAME=Matrix Rich Text Editor
 POM_DESCRIPTION=Cross-platform rich text editor that generates HTML output.

--- a/platforms/web/package.json
+++ b/platforms/web/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vector-im/matrix-wysiwyg",
-    "version": "2.37.13",
+    "version": "2.37.14",
     "type": "module",
     "description": "Wysiwyg composer for Element Web using React",
     "author": "New Vector Ltd.",


### PR DESCRIPTION
Changes:

- [Android] Have separate modes for parsing HTML for 'editor mode' and 'message mode' using `isEditor: Boolean` parameter.
- [Android] Try auto-selecting the latest NDK version available instead of using a hardcoded one.
- [Web] Update example app to use the new npm package.