### PR TITLE
[Android] Fix focus issue with compose

### DIFF
--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditText.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditText.kt
@@ -22,6 +22,7 @@ import android.text.TextWatcher
 import android.util.AttributeSet
 import android.view.KeyEvent
 import android.view.MotionEvent
+import android.view.View
 import android.view.inputmethod.BaseInputConnection
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputConnection
@@ -614,6 +615,11 @@ class EditorEditText : AppCompatEditText {
 
     override fun removeTextChangedListener(watcher: TextWatcher) {
         textWatcher.removeChild(watcher)
+    }
+
+    // This workaround is needed around compose to prevent the EditText focus from causing ANRs
+    override fun focusSearch(direction: Int): View? {
+        return null
     }
 
     override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {


### PR DESCRIPTION
When upgrading to a previous version of Compose in EXA we discovered that focusing on EditTexts often led to ANRs because the focus search seems to enter some kind of loop.

A possible workaround was to prevent this focus search, which should not be a problem for the editor AFAICT, and fixes the issue when integrating this component in a Compose layout.