### PR TITLE
[Android] Fix crashes when a code block is present and device rotates

### DIFF
--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditText.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditText.kt
@@ -616,6 +616,14 @@ class EditorEditText : AppCompatEditText {
         textWatcher.removeChild(watcher)
     }
 
+    override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
+        // The size changed, so the cached positions for the code renderers won't match anymore
+        inlineCodeBgHelper.clearCachedPositions()
+        codeBlockBgHelper.clearCachedPositions()
+
+        super.onSizeChanged(w, h, oldw, oldh)
+    }
+
     /**
      * Force redisplay the current editor model.
      *

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorStyledTextView.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorStyledTextView.kt
@@ -160,6 +160,16 @@ open class EditorStyledTextView : AppCompatTextView {
         codeBlockBgHelper.clearCachedPositions()
     }
 
+    override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
+        if (isInit) {
+            // The size changed, so the cached positions for the code renderers won't match anymore
+            inlineCodeBgHelper.clearCachedPositions()
+            codeBlockBgHelper.clearCachedPositions()
+        }
+
+        super.onSizeChanged(w, h, oldw, oldh)
+    }
+
     /**
      * Sets up the styling used to translate HTML to Spanned text.
      * @param styleConfig The styles to use for the generated spans.

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/view/inlinebg/BlockRenderer.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/view/inlinebg/BlockRenderer.kt
@@ -33,8 +33,10 @@ internal class BlockRenderer(
         text: Spanned,
         spanType: Class<*>,
     ) {
-        val top = layout.getLineTop(startLine)
-        val bottom = layout.getLineBottom(endLine)
+        val actualStartLine = startLine.coerceIn(0, layout.lineCount - 1)
+        val actualEndLine = endLine.coerceIn(0, layout.lineCount - 1)
+        val top = layout.getLineTop(actualStartLine)
+        val bottom = layout.getLineBottom(actualEndLine)
         drawable.setBounds(
             if (leadingMargin > 0) leadingMargin - horizontalPadding else horizontalPadding,
             top + verticalPadding,


### PR DESCRIPTION
This was caused by the view changing size and the cached positions for the code block renderer not being valid anymore.

Crash example: https://sentry.tools.element.io/organizations/element/issues/5645806/?project=59&query=is:unresolved&stream_index=19