### PR TITLE
Version 2.38.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# [2.38.1]
+- [Android] Workaround bug that caused the next focus view search loop when the editor is used in a Compose context, causing ANRs.
+- [Android] Fix crashes when either the editor or the rendering views contain a code block and their size changes, making the previously calculated and cached coordinates for rendering the code block invalid.
+- [Common] Change licensing to AGPLv3 + Element Commercial license. 
+
 # [2.38.0]
 - [Rust] Bump Rust version to `1.76`.
 - [Web] Bump wasm-pack version to `0.13.1`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1391,7 +1391,7 @@ dependencies = [
 
 [[package]]
 name = "uniffi-wysiwyg-composer"
-version = "2.38.0"
+version = "2.38.1"
 dependencies = [
  "html-escape",
  "matrix_mentions",
@@ -1852,7 +1852,7 @@ dependencies = [
 
 [[package]]
 name = "wysiwyg"
-version = "2.38.0"
+version = "2.38.1"
 dependencies = [
  "cfg-if",
  "email_address",
@@ -1876,7 +1876,7 @@ dependencies = [
 
 [[package]]
 name = "wysiwyg-wasm"
-version = "2.38.0"
+version = "2.38.1"
 dependencies = [
  "console_error_panic_hook",
  "html-escape",

--- a/bindings/wysiwyg-ffi/Cargo.toml
+++ b/bindings/wysiwyg-ffi/Cargo.toml
@@ -7,7 +7,7 @@ description = "Swift and Kotlin bindings for wysiwyg-rust"
 keywords = ["matrix", "chat", "messaging", "composer", "wysiwyg"]
 license-file = { workspace = true }
 name = "uniffi-wysiwyg-composer"
-version = "2.38.0"
+version = "2.38.1"
 rust-version = { workspace = true }
 
 [features]

--- a/bindings/wysiwyg-wasm/Cargo.toml
+++ b/bindings/wysiwyg-wasm/Cargo.toml
@@ -7,7 +7,7 @@ description = "WASM bindings for wysiwyg-rust"
 keywords = ["matrix", "chat", "messaging", "composer", "wysiwyg"]
 license-file = { workspace = true }
 name = "wysiwyg-wasm"
-version = "2.38.0"
+version = "2.38.1"
 rust-version = { workspace = true }
 
 [package.metadata.wasm-pack.profile.profiling]

--- a/bindings/wysiwyg-wasm/package.json
+++ b/bindings/wysiwyg-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vector-im/matrix-wysiwyg-wasm",
-  "version": "2.38.0",
+  "version": "2.38.1",
   "homepage": "https://gitlab.com/andybalaam/wysiwyg-rust",
   "description": "WASM bindings for wysiwyg-rust",
   "license": "SEE LICENSE IN README.md",

--- a/crates/wysiwyg/Cargo.toml
+++ b/crates/wysiwyg/Cargo.toml
@@ -7,7 +7,7 @@ description = "Model code to power a rich text editor for Matrix"
 keywords = ["matrix", "chat", "messaging", "composer", "wysiwyg"]
 license-file = { workspace = true }
 name = "wysiwyg"
-version = "2.38.0"
+version = "2.38.1"
 rust-version = { workspace = true }
 
 [features]

--- a/platforms/android/gradle.properties
+++ b/platforms/android/gradle.properties
@@ -23,4 +23,4 @@ android.enableBuildConfigAsBytecode=true
 # Maven publishing
 # ===================
 MAVEN_GROUP=io.element.android
-MAVEN_VERSION_NAME=2.38.0
+MAVEN_VERSION_NAME=2.38.1

--- a/platforms/web/package.json
+++ b/platforms/web/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vector-im/matrix-wysiwyg",
-    "version": "2.38.0",
+    "version": "2.38.1",
     "type": "module",
     "description": "Wysiwyg composer for Element Web using React",
     "author": "New Vector Ltd.",


### PR DESCRIPTION
Changes:

- [Android] Workaround bug that caused the next focus view search loop when the editor is used in a Compose context, causing ANRs.
- [Android] Fix crashes when either the editor or the rendering views contain a code block and their size changes, making the previously calculated and cached coordinates for rendering the code block invalid.
- [Common] Change licensing to AGPLv3 + Element Commercial license.