### PR TITLE
Version 2.38.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# [2.38.2]
+- [Android] Add line break between text nodes and block element.
+- [Web] Update vite to v6.0.9 to fix CVE in the dependency.
+
 # [2.38.1]
 - [Android] Workaround bug that caused the next focus view search loop when the editor is used in a Compose context, causing ANRs.
 - [Android] Fix crashes when either the editor or the rendering views contain a code block and their size changes, making the previously calculated and cached coordinates for rendering the code block invalid.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1391,7 +1391,7 @@ dependencies = [
 
 [[package]]
 name = "uniffi-wysiwyg-composer"
-version = "2.38.1"
+version = "2.38.2"
 dependencies = [
  "html-escape",
  "matrix_mentions",
@@ -1852,7 +1852,7 @@ dependencies = [
 
 [[package]]
 name = "wysiwyg"
-version = "2.38.1"
+version = "2.38.2"
 dependencies = [
  "cfg-if",
  "email_address",
@@ -1876,7 +1876,7 @@ dependencies = [
 
 [[package]]
 name = "wysiwyg-wasm"
-version = "2.38.1"
+version = "2.38.2"
 dependencies = [
  "console_error_panic_hook",
  "html-escape",

--- a/bindings/wysiwyg-ffi/Cargo.toml
+++ b/bindings/wysiwyg-ffi/Cargo.toml
@@ -7,7 +7,7 @@ description = "Swift and Kotlin bindings for wysiwyg-rust"
 keywords = ["matrix", "chat", "messaging", "composer", "wysiwyg"]
 license-file = { workspace = true }
 name = "uniffi-wysiwyg-composer"
-version = "2.38.1"
+version = "2.38.2"
 rust-version = { workspace = true }
 
 [features]

--- a/bindings/wysiwyg-wasm/Cargo.toml
+++ b/bindings/wysiwyg-wasm/Cargo.toml
@@ -7,7 +7,7 @@ description = "WASM bindings for wysiwyg-rust"
 keywords = ["matrix", "chat", "messaging", "composer", "wysiwyg"]
 license-file = { workspace = true }
 name = "wysiwyg-wasm"
-version = "2.38.1"
+version = "2.38.2"
 rust-version = { workspace = true }
 
 [package.metadata.wasm-pack.profile.profiling]

--- a/bindings/wysiwyg-wasm/package.json
+++ b/bindings/wysiwyg-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vector-im/matrix-wysiwyg-wasm",
-  "version": "2.38.1",
+  "version": "2.38.2",
   "homepage": "https://gitlab.com/andybalaam/wysiwyg-rust",
   "description": "WASM bindings for wysiwyg-rust",
   "license": "SEE LICENSE IN README.md",

--- a/crates/wysiwyg/Cargo.toml
+++ b/crates/wysiwyg/Cargo.toml
@@ -7,7 +7,7 @@ description = "Model code to power a rich text editor for Matrix"
 keywords = ["matrix", "chat", "messaging", "composer", "wysiwyg"]
 license-file = { workspace = true }
 name = "wysiwyg"
-version = "2.38.1"
+version = "2.38.2"
 rust-version = { workspace = true }
 
 [features]

--- a/platforms/android/gradle.properties
+++ b/platforms/android/gradle.properties
@@ -23,4 +23,4 @@ android.enableBuildConfigAsBytecode=true
 # Maven publishing
 # ===================
 MAVEN_GROUP=io.element.android
-MAVEN_VERSION_NAME=2.38.1
+MAVEN_VERSION_NAME=2.38.2

--- a/platforms/web/package.json
+++ b/platforms/web/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vector-im/matrix-wysiwyg",
-    "version": "2.38.1",
+    "version": "2.38.2",
     "type": "module",
     "description": "Wysiwyg composer for Element Web using React",
     "author": "New Vector Ltd.",


### PR DESCRIPTION
Changes:

- [Android] Add line break between text nodes and block element.
- [Web] Update vite to v6.0.9 to fix CVE in the dependency.