### PR TITLE
Update API to be able to check links

### DIFF
--- a/platforms/android/example-compose/src/main/java/io/element/wysiwyg/compose/MainActivity.kt
+++ b/platforms/android/example-compose/src/main/java/io/element/wysiwyg/compose/MainActivity.kt
@@ -157,8 +157,8 @@ class MainActivity : ComponentActivity() {
                                 .padding(16.dp),
                             resolveMentionDisplay = { _,_ -> TextDisplay.Pill },
                             resolveRoomMentionDisplay = { TextDisplay.Pill },
-                            onLinkClickedListener = { url ->
-                                Toast.makeText(this@MainActivity, "Clicked: $url", Toast.LENGTH_SHORT).show()
+                            onLinkClickedListener = { link ->
+                                Toast.makeText(this@MainActivity, "Clicked: $link", Toast.LENGTH_SHORT).show()
                             }
                         )
 

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/EditorStyledText.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/EditorStyledText.kt
@@ -23,6 +23,7 @@ import io.element.android.wysiwyg.compose.internal.rememberTypeface
 import io.element.android.wysiwyg.compose.internal.toStyleConfig
 import io.element.android.wysiwyg.display.MentionDisplayHandler
 import io.element.android.wysiwyg.display.TextDisplay
+import io.element.android.wysiwyg.link.Link
 
 /**
  * A composable EditorStyledText.
@@ -44,8 +45,8 @@ fun EditorStyledText(
     modifier: Modifier = Modifier,
     resolveMentionDisplay: (text: String, url: String) -> TextDisplay = RichTextEditorDefaults.MentionDisplay,
     resolveRoomMentionDisplay: () -> TextDisplay = RichTextEditorDefaults.RoomMentionDisplay,
-    onLinkClickedListener: ((String) -> Unit)? = null,
-    onLinkLongClickedListener: ((String) -> Unit)? = null,
+    onLinkClickedListener: ((Link) -> Unit)? = null,
+    onLinkLongClickedListener: ((Link) -> Unit)? = null,
     onTextLayout: (Layout) -> Unit = {},
     style: RichTextEditorStyle = RichTextEditorDefaults.style(),
     releaseOnDetach: Boolean = true,

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/utils/FakeLinkClickedListener.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/utils/FakeLinkClickedListener.kt
@@ -8,17 +8,18 @@
 
 package io.element.android.wysiwyg.test.utils
 
+import io.element.android.wysiwyg.link.Link
 import org.junit.Assert
 
-class FakeLinkClickedListener: (String) -> Unit {
-    private val clickedLinks: MutableList<String> = mutableListOf()
+class FakeLinkClickedListener: (Link) -> Unit {
+    private val clickedLinks: MutableList<Link> = mutableListOf()
 
-    override fun invoke(link: String) {
+    override fun invoke(link: Link) {
         clickedLinks.add(link)
     }
 
-    fun assertLinkClicked(url: String) {
+    fun assertLinkClicked(link: Link) {
         Assert.assertTrue(clickedLinks.size == 1)
-        Assert.assertTrue(clickedLinks.contains(url))
+        Assert.assertTrue(clickedLinks.contains(link))
     }
 }

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/utils/TextViewActions.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/utils/TextViewActions.kt
@@ -15,6 +15,7 @@ import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import io.element.android.wysiwyg.EditorStyledTextView
+import io.element.android.wysiwyg.link.Link
 import org.hamcrest.Matcher
 
 object TextViewAction {
@@ -46,7 +47,7 @@ object TextViewAction {
     }
 
     class SetOnLinkClickedListener(
-        private val listener: (String) -> Unit,
+        private val listener: (Link) -> Unit,
     ) : ViewAction {
         override fun getConstraints(): Matcher<View> = isDisplayed()
 
@@ -62,5 +63,5 @@ object TextViewAction {
 object TextViewActions {
     fun setText(text: CharSequence, type: BufferType = BufferType.NORMAL) = TextViewAction.SetText(text, type)
     fun setHtml(html: String) = TextViewAction.SetHtml(html)
-    fun setOnLinkClickedListener(listener: (String) -> Unit) = TextViewAction.SetOnLinkClickedListener(listener)
+    fun setOnLinkClickedListener(listener: (Link) -> Unit) = TextViewAction.SetOnLinkClickedListener(listener)
 }

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/link/Link.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/link/Link.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.wysiwyg.link
+
+/**
+ * Data class defining a link, i.e. a target url and a text.
+ * @property url The url of the string
+ * @property text The text of the link. If not provided, the url will be used, but in this case, no
+ * validation will be performed.
+ */
+data class Link(
+    val url: String,
+    val text: String = url,
+)


### PR DESCRIPTION
Introduce a `Link` data class so that the application can perform check on the link behind the text.

API break: the type of `onLinkClickedListener` and `onLinkLongClickedListener` now takes a `Link` instead of a `String`.

Context: https://github.com/element-hq/element-x-android/issues/4415