### PR TITLE
Add 'types' field to 'exports' for modern TypeScript/Node resolution.

### DIFF
--- a/platforms/web/package.json
+++ b/platforms/web/package.json
@@ -11,6 +11,7 @@
     "license": "SEE LICENSE IN README.md",
     "exports": {
         ".": {
+            "types": "./dist/index.d.ts",
             "import": "./dist/matrix-wysiwyg.js",
             "require": "./dist/matrix-wysiwyg.umd.cjs"
         }


### PR DESCRIPTION
TL;DR I ran the native port of TypeScript on Element. This PR helps make sure that Element can build cleanly with `--moduleResolution bundler`, and therefore, will build more cleanly with future versions of TypeScript.

____

If you run https://arethetypeswrong.github.io/ on this package, you'll get something like the following:

  | "@vector-im/matrix-wysiwyg"
-- | --
node10 | ✅
node16 (from CJS) | ❌ No types
node16 (from ESM) | ❌ No types
bundler | ❌ No types

While this package works:

- at runtime for ESM consumers in modern versions of Node.js, and
- at check time for TypeScript users who are using old resolution modes like `--moduleResolution node` (a.k.a. `node10`)

It will not check for projects that use modern Node.js resolution (e.g. `--moduleResolution NodeNext` or `--moduleResolution Bundler`). This matters because in upcoming versions of TypeScript, `--module node10` will be deprecated. So projects like Element will have a build error.

This fix should fix the last two rows, though I believe things will still be off if consuming files from CJS (due to [this issue](https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/FalseESM.md)). To fix that, you'll probably need slightly more involved change with a `.d.cts` file or something.

> [!NOTE]
> You can [run AreTheTypesWrong locally with the CLI](https://www.npmjs.com/package/@arethetypeswrong/cli).