### PR TITLE
Migrate to maven central portal

### DIFF
--- a/platforms/android/gradle/libs.versions.toml
+++ b/platforms/android/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ hamcrest = "3.0"
 espresso = "3.6.1"
 agp = "8.9.0"
 kotlin = "2.1.20"
-maven-publish = "0.31.0"
+maven-publish = "0.32.0"
 molecule = "2.0.0"
 
 [plugins]

--- a/platforms/android/library-compose/build.gradle
+++ b/platforms/android/library-compose/build.gradle
@@ -17,7 +17,7 @@ if (project.hasProperty("coverage")) {
 
 mavenPublishing {
     pomFromGradleProperties()
-    publishToMavenCentral(SonatypeHost.S01)
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
     signAllPublications()
 
     def publishJavaDoc = false // https://github.com/Kotlin/dokka/issues/2956

--- a/platforms/android/library/build.gradle
+++ b/platforms/android/library/build.gradle
@@ -158,7 +158,7 @@ def getNdkVersionAsWorkaround() {
 }
 
 mavenPublishing {
-    publishToMavenCentral(SonatypeHost.S01)
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
     signAllPublications()
 
     coordinates(property("MAVEN_GROUP"), property("POM_ARTIFACT_ID"), property("MAVEN_VERSION_NAME"))


### PR DESCRIPTION
Changes:

- Upgrade maven-publish plugin to compatible version.
- Update the maven repo URL by using `publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)`.