### PR TITLE
Add placeholder to RichTextEditor API

### DIFF
--- a/platforms/android/example-compose/src/main/java/io/element/wysiwyg/compose/MainActivity.kt
+++ b/platforms/android/example-compose/src/main/java/io/element/wysiwyg/compose/MainActivity.kt
@@ -129,7 +129,6 @@ class MainActivity : ComponentActivity() {
                             RichTextEditor(
                                 state = state,
                                 placeholder = "Type your message here...",
-                                placeholderColor = MaterialTheme.colorScheme.secondary,
                                 modifier = Modifier
                                     .fillMaxWidth()
                                     .padding(10.dp),

--- a/platforms/android/example-compose/src/main/java/io/element/wysiwyg/compose/MainActivity.kt
+++ b/platforms/android/example-compose/src/main/java/io/element/wysiwyg/compose/MainActivity.kt
@@ -25,7 +25,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
@@ -35,7 +34,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.element.android.wysiwyg.compose.EditorStyledText
 import io.element.android.wysiwyg.compose.RichTextEditor
@@ -96,7 +94,8 @@ class MainActivity : ComponentActivity() {
                 val htmlText = htmlConverter.fromHtmlToSpans(state.messageHtml)
 
                 linkDialogAction?.let { linkAction ->
-                    LinkDialog(linkAction = linkAction,
+                    LinkDialog(
+                        linkAction = linkAction,
                         onRemoveLink = { coroutineScope.launch { state.removeLink() } },
                         onSetLink = { coroutineScope.launch { state.setLink(it) } },
                         onInsertLink = { url, text ->
@@ -136,7 +135,7 @@ class MainActivity : ComponentActivity() {
                                     .padding(10.dp),
                                 style = RichTextEditorDefaults.style(),
                                 onError = { Timber.e(it) },
-                                resolveMentionDisplay = { _,_ -> TextDisplay.Pill },
+                                resolveMentionDisplay = { _, _ -> TextDisplay.Pill },
                                 resolveRoomMentionDisplay = { TextDisplay.Pill },
                                 onTyping = { isTyping = it }
                             )
@@ -157,10 +156,14 @@ class MainActivity : ComponentActivity() {
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .padding(16.dp),
-                            resolveMentionDisplay = { _,_ -> TextDisplay.Pill },
+                            resolveMentionDisplay = { _, _ -> TextDisplay.Pill },
                             resolveRoomMentionDisplay = { TextDisplay.Pill },
                             onLinkClickedListener = { link ->
-                                Toast.makeText(this@MainActivity, "Clicked: $link", Toast.LENGTH_SHORT).show()
+                                Toast.makeText(
+                                    this@MainActivity,
+                                    "Clicked: $link",
+                                    Toast.LENGTH_SHORT
+                                ).show()
                             }
                         )
 
@@ -234,18 +237,3 @@ class MainActivity : ComponentActivity() {
         }
     }
 }
-
-@Preview
-@Composable
-fun EditorPreview() {
-    RichTextEditorTheme {
-        val state = rememberRichTextEditorState("Hello, world")
-        RichTextEditor(
-            state = state,
-            placeholder = "Type your message here...",
-            placeholderColor = MaterialTheme.colorScheme.secondary,
-            modifier = Modifier.fillMaxWidth(),
-        )
-    }
-}
-

--- a/platforms/android/example-compose/src/main/java/io/element/wysiwyg/compose/MainActivity.kt
+++ b/platforms/android/example-compose/src/main/java/io/element/wysiwyg/compose/MainActivity.kt
@@ -129,6 +129,8 @@ class MainActivity : ComponentActivity() {
                         ) {
                             RichTextEditor(
                                 state = state,
+                                placeholder = "Type your message here...",
+                                placeholderColor = MaterialTheme.colorScheme.secondary,
                                 modifier = Modifier
                                     .fillMaxWidth()
                                     .padding(10.dp),
@@ -240,6 +242,8 @@ fun EditorPreview() {
         val state = rememberRichTextEditorState("Hello, world")
         RichTextEditor(
             state = state,
+            placeholder = "Type your message here...",
+            placeholderColor = MaterialTheme.colorScheme.secondary,
             modifier = Modifier.fillMaxWidth(),
         )
     }

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditor.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditor.kt
@@ -12,6 +12,11 @@ import android.content.res.ColorStateList
 import android.net.Uri
 import android.view.View
 import androidx.appcompat.widget.AppCompatEditText
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -21,6 +26,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.widget.addTextChangedListener
 import io.element.android.wysiwyg.EditorEditText
@@ -142,9 +149,10 @@ private fun RealEditor(
                             state.actions = actionStates
                         }
 
-                    selectionChangeListener = EditorEditText.OnSelectionChangeListener { start, end ->
-                        state.selection = start to end
-                    }
+                    selectionChangeListener =
+                        EditorEditText.OnSelectionChangeListener { start, end ->
+                            state.selection = start to end
+                        }
                     menuActionListener = EditorEditText.OnMenuActionChangedListener { menuAction ->
                         state.menuAction = menuAction
                     }
@@ -172,9 +180,10 @@ private fun RealEditor(
                         state.onFocusChanged(view.hashCode(), hasFocus)
                     }
 
-                    mentionsStateChangedListener = EditorEditText.OnMentionsStateChangedListener { mentionsState ->
-                        state.mentionsState = mentionsState
-                    }
+                    mentionsStateChangedListener =
+                        EditorEditText.OnMentionsStateChangedListener { mentionsState ->
+                            state.mentionsState = mentionsState
+                        }
                 }
 
                 applyDefaultStyle()
@@ -207,7 +216,10 @@ private fun RealEditor(
                                     is ViewAction.RemoveLink -> removeLink()
                                     is ViewAction.InsertLink -> insertLink(it.url, it.text)
                                     is ViewAction.ReplaceSuggestionText -> replaceTextSuggestion(it.text)
-                                    is ViewAction.InsertMentionAtSuggestion -> insertMentionAtSuggestion(url = it.url, text = it.text)
+                                    is ViewAction.InsertMentionAtSuggestion -> insertMentionAtSuggestion(
+                                        url = it.url,
+                                        text = it.text
+                                    )
                                     is ViewAction.InsertAtRoomMentionAtSuggestion -> insertAtRoomMentionAtSuggestion()
                                     is ViewAction.SetSelection -> setSelection(it.start, it.end)
                                 }
@@ -219,7 +231,9 @@ private fun RealEditor(
         },
         update = { view ->
             Timber.i("RichTextEditor update() called")
-            if (inputType != view.inputType) { view.inputType = inputType }
+            if (inputType != view.inputType) {
+                view.inputType = inputType
+            }
             view.applyStyleInCompose(style)
             view.typeface = typeface
             view.updateStyle(style.toStyleConfig(view.context), mentionDisplayHandler)
@@ -264,4 +278,42 @@ private fun PreviewEditor(
     }, update = { view ->
         view.applyStyleInCompose(style)
     })
+}
+
+@Preview
+@Composable
+internal fun RichTextEditorPlaceholderPreview() {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(Color.White)
+            .padding(16.dp)
+    ) {
+        RichTextEditor(
+            state = rememberRichTextEditorState(),
+            placeholder = "Type your message here...",
+            placeholderColor = Color.Gray,
+            style = RichTextEditorDefaults.style(),
+            registerStateUpdates = false,
+        )
+    }
+}
+
+@Preview
+@Composable
+internal fun RichTextEditorPreview() {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(Color.White)
+            .padding(16.dp)
+    ) {
+        val state = rememberRichTextEditorState("Hello, world")
+        RichTextEditor(
+            state = state,
+            placeholder = "Type your message here...",
+            placeholderColor = MaterialTheme.colorScheme.secondary,
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
 }

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditor.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditor.kt
@@ -8,6 +8,7 @@
 
 package io.element.android.wysiwyg.compose
 
+import android.content.res.ColorStateList
 import android.net.Uri
 import android.view.View
 import androidx.appcompat.widget.AppCompatEditText
@@ -16,6 +17,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.viewinterop.AndroidView
@@ -57,6 +60,8 @@ import timber.log.Timber
 fun RichTextEditor(
     modifier: Modifier = Modifier,
     state: RichTextEditorState = rememberRichTextEditorState(),
+    placeholder: String,
+    placeholderColor: Color,
     registerStateUpdates: Boolean = true,
     style: RichTextEditorStyle = RichTextEditorDefaults.style(),
     inputType: Int = RichTextEditorDefaults.inputType,
@@ -69,10 +74,18 @@ fun RichTextEditor(
     val isPreview = LocalInspectionMode.current
 
     if (isPreview) {
-        PreviewEditor(state, modifier, style)
+        PreviewEditor(
+            state = state,
+            placeholder = placeholder,
+            placeholderColor = placeholderColor,
+            modifier = modifier,
+            style = style,
+        )
     } else {
         RealEditor(
             state = state,
+            placeholder = placeholder,
+            placeholderColor = placeholderColor,
             registerStateUpdates = registerStateUpdates,
             modifier = modifier,
             style = style,
@@ -89,6 +102,8 @@ fun RichTextEditor(
 @Composable
 private fun RealEditor(
     state: RichTextEditorState,
+    placeholder: String,
+    placeholderColor: Color,
     registerStateUpdates: Boolean,
     modifier: Modifier = Modifier,
     style: RichTextEditorStyle,
@@ -167,7 +182,8 @@ private fun RealEditor(
                 // Set initial HTML and selection based on the provided state
                 setHtml(state.internalHtml)
                 setSelection(state.selection.first, state.selection.second)
-
+                setHint(placeholder)
+                setHintTextColor(ColorStateList.valueOf(placeholderColor.toArgb()))
                 setOnRichContentSelected(onRichContentSelected)
                 // Only start listening for text changes after the initial state has been restored
                 if (registerStateUpdates) {
@@ -224,6 +240,8 @@ private fun RealEditor(
 @Composable
 private fun PreviewEditor(
     state: RichTextEditorState,
+    placeholder: String,
+    placeholderColor: Color,
     modifier: Modifier = Modifier,
     style: RichTextEditorStyle,
 ) {
@@ -238,6 +256,8 @@ private fun PreviewEditor(
             applyDefaultStyle()
 
             setText(state.messageHtml)
+            setHint(placeholder)
+            setHintTextColor(placeholderColor.toArgb())
         }
 
         view

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditor.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditor.kt
@@ -68,7 +68,6 @@ fun RichTextEditor(
     modifier: Modifier = Modifier,
     state: RichTextEditorState = rememberRichTextEditorState(),
     placeholder: String,
-    placeholderColor: Color,
     registerStateUpdates: Boolean = true,
     style: RichTextEditorStyle = RichTextEditorDefaults.style(),
     inputType: Int = RichTextEditorDefaults.inputType,
@@ -84,7 +83,6 @@ fun RichTextEditor(
         PreviewEditor(
             state = state,
             placeholder = placeholder,
-            placeholderColor = placeholderColor,
             modifier = modifier,
             style = style,
         )
@@ -92,7 +90,6 @@ fun RichTextEditor(
         RealEditor(
             state = state,
             placeholder = placeholder,
-            placeholderColor = placeholderColor,
             registerStateUpdates = registerStateUpdates,
             modifier = modifier,
             style = style,
@@ -110,7 +107,6 @@ fun RichTextEditor(
 private fun RealEditor(
     state: RichTextEditorState,
     placeholder: String,
-    placeholderColor: Color,
     registerStateUpdates: Boolean,
     modifier: Modifier = Modifier,
     style: RichTextEditorStyle,
@@ -192,7 +188,7 @@ private fun RealEditor(
                 setHtml(state.internalHtml)
                 setSelection(state.selection.first, state.selection.second)
                 setHint(placeholder)
-                setHintTextColor(ColorStateList.valueOf(placeholderColor.toArgb()))
+                setHintTextColor(ColorStateList.valueOf(style.text.placeholderColor.toArgb()))
                 setOnRichContentSelected(onRichContentSelected)
                 // Only start listening for text changes after the initial state has been restored
                 if (registerStateUpdates) {
@@ -255,7 +251,6 @@ private fun RealEditor(
 private fun PreviewEditor(
     state: RichTextEditorState,
     placeholder: String,
-    placeholderColor: Color,
     modifier: Modifier = Modifier,
     style: RichTextEditorStyle,
 ) {
@@ -271,7 +266,7 @@ private fun PreviewEditor(
 
             setText(state.messageHtml)
             setHint(placeholder)
-            setHintTextColor(placeholderColor.toArgb())
+            setHintTextColor(style.text.placeholderColor.toArgb())
         }
 
         view
@@ -292,7 +287,6 @@ internal fun RichTextEditorPlaceholderPreview() {
         RichTextEditor(
             state = rememberRichTextEditorState(),
             placeholder = "Type your message here...",
-            placeholderColor = Color.Gray,
             style = RichTextEditorDefaults.style(),
             registerStateUpdates = false,
         )
@@ -312,7 +306,6 @@ internal fun RichTextEditorPreview() {
         RichTextEditor(
             state = state,
             placeholder = "Type your message here...",
-            placeholderColor = MaterialTheme.colorScheme.secondary,
             modifier = Modifier.fillMaxWidth(),
         )
     }

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditor.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditor.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditorDefaults.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditorDefaults.kt
@@ -150,6 +150,7 @@ object RichTextEditorDefaults {
      * Creates the default text style for [RichTextEditor].
      *
      * @param color The text color to apply
+     * @param placeholderColor The color to apply to the placeholder
      * @param fontSize The font size to apply
      * @param lineHeight The line height to apply
      * @param fontFamily The font family to apply
@@ -161,6 +162,7 @@ object RichTextEditorDefaults {
     @Composable
     fun textStyle(
         color: Color = LocalContentColor.current,
+        placeholderColor: Color = MaterialTheme.colorScheme.secondary,
         fontSize: TextUnit = LocalTextStyle.current.fontSize,
         lineHeight: TextUnit = LocalTextStyle.current.lineHeight,
         fontFamily: FontFamily? = LocalTextStyle.current.fontFamily,
@@ -170,6 +172,7 @@ object RichTextEditorDefaults {
         includeFontPadding: Boolean = true,
     ) = TextStyle(
         color = color,
+        placeholderColor = placeholderColor,
         fontSize = fontSize,
         lineHeight = lineHeight,
         fontFamily = fontFamily,
@@ -231,7 +234,7 @@ object RichTextEditorDefaults {
         color: Color = MaterialTheme.colorScheme.secondaryContainer,
         borderColor: Color = MaterialTheme.colorScheme.onSecondaryContainer,
         cornerRadius: Dp = defaultCodeCornerRadius,
-        borderWidth: Dp = defaultCodeBorderWidth
+        borderWidth: Dp = defaultCodeBorderWidth,
     ): InlineCodeBackgroundStyle {
         val density = LocalDensity.current
         return InlineCodeBackgroundStyle(

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditorStyle.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditorStyle.kt
@@ -58,6 +58,7 @@ data class PillStyle(
 
 data class TextStyle(
     val color: Color,
+    val placeholderColor: Color,
     val fontSize: TextUnit,
     val lineHeight: TextUnit,
     val fontFamily: FontFamily?,


### PR DESCRIPTION
In the context of https://github.com/element-hq/element-x-android/pull/4900, add 2 parameters to the RichTextEditor composable to provide a placeholder.