### PR TITLE
Version 2.38.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# [2.38.5]
+- [Rust] Add support for `<ol start='N'>` attribute.
+- [Android] Add support for `<ol start='N'>` attribute when rendering HTML.
+- [Android] Improve how new line characters are handled inside HTML tags when rendered.
+
 # [2.38.4]
 - [Android] Add placeholder to RichTextEditor API #63
 - [Android] Migrate to maven central portal #62

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1481,7 +1481,7 @@ dependencies = [
 
 [[package]]
 name = "uniffi-wysiwyg-composer"
-version = "2.38.4"
+version = "2.38.5"
 dependencies = [
  "html-escape",
  "matrix_mentions",
@@ -1893,7 +1893,7 @@ checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "wysiwyg"
-version = "2.38.4"
+version = "2.38.5"
 dependencies = [
  "cfg-if",
  "email_address",
@@ -1917,7 +1917,7 @@ dependencies = [
 
 [[package]]
 name = "wysiwyg-wasm"
-version = "2.38.4"
+version = "2.38.5"
 dependencies = [
  "console_error_panic_hook",
  "html-escape",

--- a/bindings/wysiwyg-ffi/Cargo.toml
+++ b/bindings/wysiwyg-ffi/Cargo.toml
@@ -7,7 +7,7 @@ description = "Swift and Kotlin bindings for wysiwyg-rust"
 keywords = ["matrix", "chat", "messaging", "composer", "wysiwyg"]
 license-file = { workspace = true }
 name = "uniffi-wysiwyg-composer"
-version = "2.38.4"
+version = "2.38.5"
 rust-version = { workspace = true }
 
 [features]

--- a/bindings/wysiwyg-wasm/Cargo.toml
+++ b/bindings/wysiwyg-wasm/Cargo.toml
@@ -7,7 +7,7 @@ description = "WASM bindings for wysiwyg-rust"
 keywords = ["matrix", "chat", "messaging", "composer", "wysiwyg"]
 license-file = { workspace = true }
 name = "wysiwyg-wasm"
-version = "2.38.4"
+version = "2.38.5"
 rust-version = { workspace = true }
 
 [package.metadata.wasm-pack.profile.profiling]

--- a/bindings/wysiwyg-wasm/package.json
+++ b/bindings/wysiwyg-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vector-im/matrix-wysiwyg-wasm",
-  "version": "2.38.4",
+  "version": "2.38.5",
   "homepage": "https://gitlab.com/andybalaam/wysiwyg-rust",
   "description": "WASM bindings for wysiwyg-rust",
   "license": "SEE LICENSE IN README.md",

--- a/crates/wysiwyg/Cargo.toml
+++ b/crates/wysiwyg/Cargo.toml
@@ -7,7 +7,7 @@ description = "Model code to power a rich text editor for Matrix"
 keywords = ["matrix", "chat", "messaging", "composer", "wysiwyg"]
 license-file = { workspace = true }
 name = "wysiwyg"
-version = "2.38.4"
+version = "2.38.5"
 rust-version = { workspace = true }
 
 [features]

--- a/platforms/android/gradle.properties
+++ b/platforms/android/gradle.properties
@@ -23,4 +23,4 @@ android.enableBuildConfigAsBytecode=true
 # Maven publishing
 # ===================
 MAVEN_GROUP=io.element.android
-MAVEN_VERSION_NAME=2.38.4
+MAVEN_VERSION_NAME=2.38.5

--- a/platforms/web/package.json
+++ b/platforms/web/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vector-im/matrix-wysiwyg",
-    "version": "2.38.4",
+    "version": "2.38.5",
     "type": "module",
     "description": "Wysiwyg composer for Element Web using React",
     "author": "New Vector Ltd.",


### PR DESCRIPTION
# [2.38.5]
- [Rust] Add support for `<ol start='N'>` attribute.
- [Android] Add support for `<ol start='N'>` attribute when rendering HTML.
- [Android] Improve how new line characters are handled inside HTML tags when rendered.