### PR TITLE
Replace polling loop in initOnce with shared promise

### DIFF
--- a/platforms/web/lib/useComposerModel.ts
+++ b/platforms/web/lib/useComposerModel.ts
@@ -17,32 +17,17 @@ import {
 
 import { replaceEditor } from './dom';
 
-let initStarted = false;
-let initFinished = false;
+let initPromise: Promise<void> | null = null;
 
 /**
  * Initialise the WASM module, or do nothing if it is already initialised.
+ * Safe to call concurrently — all callers share the same underlying promise.
  */
 export async function initOnce(): Promise<void> {
-    if (initFinished) {
-        return Promise.resolve();
+    if (!initPromise) {
+        initPromise = initAsync();
     }
-    if (initStarted) {
-        // Wait until the other init call has finished
-        return new Promise<void>((resolve) => {
-            function tryResolve(): void {
-                if (initFinished) {
-                    resolve();
-                }
-                setTimeout(tryResolve, 200);
-            }
-            tryResolve();
-        });
-    }
-
-    initStarted = true;
-    await initAsync();
-    initFinished = true;
+    return initPromise;
 }
 
 export function useComposerModel(


### PR DESCRIPTION
React StrictMode double-invokes effects, causing two concurrent init() calls. The previous polling approach resolved ~200ms after WASM loaded for the second caller, occasionally creating a fresh empty ComposerModel mid-operation.

Replace the initStarted/initFinished flags and setTimeout polling with a single shared promise so all concurrent callers await the same initialisation and never get a stale result.