### PR TITLE
Android: fix `Element.isBlock` checks for adding new lines

### DIFF
--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToSpansParser.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToSpansParser.kt
@@ -119,7 +119,7 @@ internal class HtmlToSpansParser(
         if (text.isEmpty()) return
 
         val previousSibling = child.previousSibling() as? Element
-        if (previousSibling != null && previousSibling.isBlock && !isLineBreak(previousSibling)) {
+        if (previousSibling != null && previousSibling.isBlockElement() && !isLineBreak(previousSibling)) {
             append('\n')
         }
         append(text)
@@ -141,7 +141,7 @@ internal class HtmlToSpansParser(
 
     private fun SpannableStringBuilder.parseLineBreak(element: Element) {
         val previousElementSibling = element.previousElementSibling()
-        if (previousElementSibling?.isBlock == true && !isLineBreak(previousElementSibling)) {
+        if (previousElementSibling?.isBlockElement() == true && !isLineBreak(previousElementSibling)) {
             append('\n')
         }
         append('\n')
@@ -287,7 +287,7 @@ internal class HtmlToSpansParser(
      * character exists, set it as extra character so it's ignored when mapping indexes.
      */
     private fun SpannableStringBuilder.handleNbspInBlock(element: Element, start: Int, end: Int) {
-        if (!element.isBlock) return
+        if (!element.isBlockElement()) return
 
         if (element.childNodes().isEmpty() && this.isNotEmpty()) {
             this.append(NBSP)
@@ -307,7 +307,7 @@ internal class HtmlToSpansParser(
         }
 
         // If current element is not a block there's no need to add line breaks
-        if (!element.isBlock) return
+        if (!element.isBlockElement()) return
 
         // Pick the previous sibling node in the DOM
         var previousSibling = element.previousSibling()
@@ -455,5 +455,17 @@ internal class HtmlToSpansParser(
                 "Spans in text contain invalid spans.\n\n${textSpans.joinToString("\n")}"
             }
         }
+    }
+
+    /**
+     * Jsoup's [Element.isBlock] method treats various tags incorrectly as block elements, like
+     * `del` or `code`, which causes unwanted line breaks in the rendered text.
+     * This method implements a check with a subset of known block elements.
+     */
+    fun Element.isBlockElement(): Boolean {
+        return tagName() in listOf(
+            "p", "ul", "ol", "li", "hr", "pre", "blockquote", "div",
+            "h1", "h2", "h3", "h4", "h5", "h6",
+        )
     }
 }

--- a/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/utils/HtmlToSpansParserTest.kt
+++ b/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/utils/HtmlToSpansParserTest.kt
@@ -308,6 +308,29 @@ class HtmlToSpansParserTest {
         )
     }
 
+    @Test
+    fun testLineBreakNotAddedAfterStrikethroughOrCodeTags() {
+        val htmlStrikethrough = "Testing <del>strikethrough</del>$NBSP"
+        val spannedStrikeThrough = convertHtml(
+            html = htmlStrikethrough,
+            isEditor = false,
+        )
+        assertThat(
+            spannedStrikeThrough.toString(),
+            equalTo("Testing strikethrough$NBSP")
+        )
+
+        val htmlCode = "Testing <code>inline code</code>$NBSP"
+        val spannedStrikeCode = convertHtml(
+            html = htmlCode,
+            isEditor = false,
+        )
+        assertThat(
+            spannedStrikeCode.toString(),
+            equalTo("Testing inline code$NBSP")
+        )
+    }
+
     private fun convertHtml(
         html: String,
         isEditor: Boolean = true,


### PR DESCRIPTION
Jsoup seems to have changed some behaviour in `Element.isBlock`/`Tag.isBlock` that considers `del`, `code` and other inline tags block tags instead. This breaks our logic for adding vertical spacing by using line breaks after block tags, incorrectly adding line breaks after these inline tags when there are `NBSP` or other whitespace chars after them.

To test this, you can revert the calls to the new `Element.isBlockElement()` extension function to the previous `Element.isBlock()` and run the new test: you'll see a `\n` character added at the end.

Fixes https://github.com/element-hq/element-x-android/issues/1078