### PR TITLE
Use Compose BOM from the version catalog

### DIFF
--- a/platforms/android/library-compose/build.gradle
+++ b/platforms/android/library-compose/build.gradle
@@ -80,6 +80,7 @@ dependencies {
 
     implementation libs.timber
     implementation libs.androidx.appcompat
+    implementation platform(libs.androidx.compose.bom)
     implementation 'androidx.compose.material3:material3'
     releaseImplementation 'androidx.compose.ui:ui-tooling-preview'
     debugImplementation "androidx.compose.ui:ui-tooling"


### PR DESCRIPTION
Publishing to Maven was failing with:

```
pkg:maven/io.element.android/wysiwyg-compose@2.41.3
Error: Dependency version information is missing for dependency: androidx.compose.ui:ui-tooling-preview
Error: Dependency version information is missing for dependency: androidx.compose.material3:material3
```

It seems like it happens because we forgot to link the BOM in the `library-compose` module. I'm surprised this was working before, to be honest 😅 .