### PR TITLE
Version 2.42.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+# [2.42.0]
+- [iOS] Migrate to Swift 6 and the Swift Testing framework, adopt approachable concurrency, and update build settings and minimum deployment versions #125
+- [iOS] Update Swift dependencies and regenerate the UniFFI Swift bindings for the updated uniffi #68 #127
+- [Web] Fix a race in the composer model initialisation by replacing the polling loop with a shared promise #116
+- [Web] Update dependencies (TypeScript 6, Vite 8, wasm-pack 0.15) #103 #110 #111
+- [Android] Use the Compose BOM from the version catalog #121
+- [Rust] Update dependencies (html5ever, strum, uniffi, speculoos) #59
+- [Common] Update the Rust toolchain to 1.91 and fix the CI build #127
+- [Common] Update GitHub Actions #102 #107
+
 # [2.41.3]
 - [Android] Fix some inline tags being processed as block tags and adding extra line breaks #118
 - [Android] Update dependencies #113

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1477,7 +1477,7 @@ dependencies = [
 
 [[package]]
 name = "uniffi-wysiwyg-composer"
-version = "2.41.3"
+version = "2.42.0"
 dependencies = [
  "html-escape",
  "matrix_mentions",
@@ -2043,7 +2043,7 @@ checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "wysiwyg"
-version = "2.41.3"
+version = "2.42.0"
 dependencies = [
  "cfg-if",
  "email_address",
@@ -2067,7 +2067,7 @@ dependencies = [
 
 [[package]]
 name = "wysiwyg-wasm"
-version = "2.41.3"
+version = "2.42.0"
 dependencies = [
  "console_error_panic_hook",
  "html-escape",

--- a/bindings/wysiwyg-ffi/Cargo.toml
+++ b/bindings/wysiwyg-ffi/Cargo.toml
@@ -7,7 +7,7 @@ description = "Swift and Kotlin bindings for wysiwyg-rust"
 keywords = ["matrix", "chat", "messaging", "composer", "wysiwyg"]
 license-file = { workspace = true }
 name = "uniffi-wysiwyg-composer"
-version = "2.41.3"
+version = "2.42.0"
 rust-version = { workspace = true }
 
 [features]

--- a/bindings/wysiwyg-wasm/Cargo.toml
+++ b/bindings/wysiwyg-wasm/Cargo.toml
@@ -7,7 +7,7 @@ description = "WASM bindings for wysiwyg-rust"
 keywords = ["matrix", "chat", "messaging", "composer", "wysiwyg"]
 license-file = { workspace = true }
 name = "wysiwyg-wasm"
-version = "2.41.3"
+version = "2.42.0"
 rust-version = { workspace = true }
 
 [package.metadata.wasm-pack.profile.profiling]

--- a/bindings/wysiwyg-wasm/package.json
+++ b/bindings/wysiwyg-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vector-im/matrix-wysiwyg-wasm",
-  "version": "2.41.3",
+  "version": "2.42.0",
   "homepage": "https://gitlab.com/andybalaam/wysiwyg-rust",
   "description": "WASM bindings for wysiwyg-rust",
   "license": "SEE LICENSE IN README.md",

--- a/crates/wysiwyg/Cargo.toml
+++ b/crates/wysiwyg/Cargo.toml
@@ -7,7 +7,7 @@ description = "Model code to power a rich text editor for Matrix"
 keywords = ["matrix", "chat", "messaging", "composer", "wysiwyg"]
 license-file = { workspace = true }
 name = "wysiwyg"
-version = "2.41.3"
+version = "2.42.0"
 rust-version = { workspace = true }
 
 [features]

--- a/platforms/android/gradle.properties
+++ b/platforms/android/gradle.properties
@@ -23,4 +23,4 @@ android.enableBuildConfigAsBytecode=true
 # Maven publishing
 # ===================
 MAVEN_GROUP=io.element.android
-MAVEN_VERSION_NAME=2.41.3
+MAVEN_VERSION_NAME=2.42.0

--- a/platforms/web/package.json
+++ b/platforms/web/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vector-im/matrix-wysiwyg",
-    "version": "2.41.3",
+    "version": "2.42.0",
     "type": "module",
     "description": "Wysiwyg composer for Element Web using React",
     "author": "New Vector Ltd.",


### PR DESCRIPTION
- [iOS] Migrate to Swift 6 and the Swift Testing framework, adopt approachable concurrency, and update build settings and minimum deployment versions #125
- [iOS] Update Swift dependencies and regenerate the UniFFI Swift bindings for the updated uniffi #68 #127
- [Web] Fix a race in the composer model initialisation by replacing the polling loop with a shared promise #116
- [Web] Update dependencies (TypeScript 6, Vite 8, wasm-pack 0.15) #103 #110 #111
- [Android] Use the Compose BOM from the version catalog #121
- [Rust] Update dependencies (html5ever, strum, uniffi, speculoos) #59
- [Common] Update the Rust toolchain to 1.91 and fix the CI build #127
- [Common] Update GitHub Actions #102 #107