### PR TITLE
Fix ordered list number rendering for item numbers > 99

### DIFF
--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/view/spans/OrderedListSpan.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/view/spans/OrderedListSpan.kt
@@ -28,7 +28,7 @@ class OrderedListSpan(
 ) : LeadingMarginSpan, BlockSpan {
 
     private val prefix = "$order."
-    private val prefixToMeasure = "99."
+    private val prefixToMeasure = if (prefix.length > 3) prefix else "99."
 
     private val typefacePaint = Paint().apply {
         this.textSize = textSize


### PR DESCRIPTION
# Issue

Previously, a message like "150. thing" was misleadingly rendered as "50. thing". OrderedListSpan sets a fixed width for list item numbers, presumably in an attempt to right-align them for prettier rendering in actual lists.

## Example

On Element X 26.05.2 (F-Droid), the following message (per View Source)

```json
{
  "content": {
    "body": "150. Foo",
    "format": "org.matrix.custom.html",
    "formatted_body": "<ol start=\"150\">\n<li>Foo</li>\n</ol>\n",
    "m.mentions": {},
    "msgtype": "m.text"
  },
  "event_id": "$...",
  "origin_server_ts": 1781558810751,
  "sender": "@...",
  "type": "m.room.message",
  "unsigned": {
    "age": 158,
    "membership": "join"
  }
}
```

is rendered as

<img width="529" height="219" alt="1000003536" src="https://github.com/user-attachments/assets/c88aa2a7-7244-4aae-9abd-d161d997763b" />

# Fix (maybe)

Not all lists are contiguously numbered from 1, and showing the actual numbers is more important than visual alignment, so measure the full prefix width if it is longer than the default.

### Warnings

- I have not fully tested this fix. Though it seems quite likely to me that this will help, and the code at least compiles, I didn't test integration into Element X to see if the issue is solved.

- This does not preserve right-alignment of lists with numbers larger than 99, but then those were broken anyway.
- The "99." might not just be about string length, but character width (as 9 is often visually wider than e.g. 1), and it might be desirable to construct a "9999." string of prefix.length characters.