### PR TITLE
Support <s> and <strike> as strikethrough tags

### DIFF
--- a/crates/wysiwyg/src/dom/parser/parse.rs
+++ b/crates/wysiwyg/src/dom/parser/parse.rs
@@ -256,7 +256,12 @@ mod sys {
 
             if invalid_node_error.is_none() {
                 match tag {
-                    "b" | "code" | "del" | "em" | "i" | "strong" | "u" => {
+                    "b" | "code" | "del" | "em" | "i" | "s" | "strike"
+                    | "strong" | "u" => {
+                        let tag = match tag {
+                            "s" | "strike" => "del",
+                            _ => tag,
+                        };
                         let formatting_node = Self::new_formatting(tag);
                         if tag == "code"
                             && self.current_path.contains(&CodeBlock)
@@ -698,6 +703,28 @@ mod sys {
         #[test]
         fn parse_simple_tag() {
             assert_that!("<strong>sdfds</strong>").roundtrips();
+        }
+
+        #[test]
+        fn parse_del_tag() {
+            assert_that!("<del>gone</del>").roundtrips();
+        }
+
+        #[test]
+        fn parse_s_and_strike_tags_as_strikethrough() {
+            for html in ["<s>gone</s>", "<strike>gone</strike>"] {
+                let dom = parse::<Utf16String>(html).unwrap();
+                assert_eq!(dom.to_html().to_string(), "<del>gone</del>");
+            }
+        }
+
+        #[test]
+        fn parse_s_tag_nested_in_another_tag() {
+            let dom = parse::<Utf16String>("<b>kept <s>gone</s></b>").unwrap();
+            assert_eq!(
+                dom.to_html().to_string(),
+                "<b>kept <del>gone</del></b>"
+            );
         }
 
         #[test]
@@ -1928,7 +1955,9 @@ mod js {
                             let formatting_kind = match node_name {
                                 "STRONG" | "B" => Some(InlineFormatType::Bold),
                                 "EM" | "I" => Some(InlineFormatType::Italic),
-                                "DEL" => Some(InlineFormatType::StrikeThrough),
+                                "DEL" | "S" | "STRIKE" => {
+                                    Some(InlineFormatType::StrikeThrough)
+                                }
                                 "U" => Some(InlineFormatType::Underline),
                                 "CODE" => Some(InlineFormatType::InlineCode),
                                 "SPAN" => {

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToDomParser.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToDomParser.kt
@@ -14,8 +14,8 @@ object HtmlToDomParser {
 
     private val safeList = Safelist()
         .addTags(
-            "a", "b", "strong", "i", "em", "u", "del", "code", "ul", "ol", "li", "pre",
-            "blockquote", "p", "br"
+            "a", "b", "strong", "i", "em", "u", "del", "s", "strike", "code", "ul", "ol", "li",
+            "pre", "blockquote", "p", "br"
         )
         .addAttributes("a", "href", "data-mention-type", "contenteditable")
         .addAttributes("ol", "start")

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToSpansParser.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToSpansParser.kt
@@ -83,7 +83,7 @@ internal class HtmlToSpansParser(
             "b", "strong" -> parseInlineFormatting(element, InlineFormat.Bold)
             "i", "em" -> parseInlineFormatting(element, InlineFormat.Italic)
             "u" -> parseInlineFormatting(element, InlineFormat.Underline)
-            "del" -> parseInlineFormatting(element, InlineFormat.StrikeThrough)
+            "del", "s", "strike" -> parseInlineFormatting(element, InlineFormat.StrikeThrough)
             // Note we're using a different method for inline code
             "code" -> parseInlineCode(element)
             "ul", "ol" -> parseList(element)

--- a/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/utils/HtmlToSpansParserTest.kt
+++ b/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/utils/HtmlToSpansParserTest.kt
@@ -52,6 +52,37 @@ class HtmlToSpansParserTest {
     }
 
     @Test
+    fun testStrikethroughTagVariants() {
+        val html = "<del>del</del>" +
+                "<s>s</s>" +
+                "<strike>strike</strike>"
+        val spanned = convertHtml(html)
+
+        assertThat(
+            spanned.dumpSpans(), equalTo(
+                listOf(
+                    "del: android.text.style.StrikethroughSpan (0-3) fl=#17",
+                    "s: android.text.style.StrikethroughSpan (3-4) fl=#17",
+                    "strike: android.text.style.StrikethroughSpan (4-10) fl=#17",
+                )
+            )
+        )
+    }
+
+    @Test
+    fun testStrikethroughTagVariantsNestedInOtherTags() {
+        val html = "<p>kept <s>gone</s></p>"
+        val spanned = convertHtml(html)
+
+        assertThat(spanned.toString(), equalTo("kept gone"))
+        assertThat(
+            spanned.dumpSpans(), contains(
+                "gone: android.text.style.StrikethroughSpan (5-9) fl=#17",
+            )
+        )
+    }
+
+    @Test
     fun testLists() {
         val html = """
             <ol>


### PR DESCRIPTION
# Issue

A message whose `formatted_body` uses `<s>` or `<strike>` for strikethrough renders as ordinary text — the line through it is gone, with nothing to show the sender applied any formatting. Only `<del>` works today.

`<s>` is in the Matrix specification's [suggested set of permitted tags](https://spec.matrix.org/latest/client-server-api/#mroommessage-msgtypes), where it replaced `<strike>` in spec v1.10. `<strike>` was the listed tag up to v1.9 and is still emitted by clients built against it, so both turn up in real messages. Cinny sends `<s>`, which is how this was reported: element-hq/element-x-android#4328.

# Fix

**Android** — the display path dropped the formatting silently. `HtmlToDomParser`'s `Safelist` unwrapped both tags before parsing, and `HtmlToSpansParser` dispatched on `del` alone. Both now recognise `s` and `strike` and map them to `InlineFormat.StrikeThrough`.

**Rust** — the composer rejected them outright. Parsing HTML from a Matrix source returned ``Node `s` is not supported``, so a message using either tag could not be loaded into the composer at all. The `sys` parser now accepts both and normalises them to `del` before building the formatting node, so the model holds a single strikethrough tag and serialises the same HTML back out. The `js` parser maps `S` and `STRIKE` alongside `DEL`, which already normalises via `InlineFormatType::tag()`.

Normalising rather than keeping the original tag name is what keeps the change contained: `InlineFormatType` has one `StrikeThrough` variant that serialises as `del`, so admitting a second spelling into the model would mean either a new variant or a node whose name and kind disagree.

This does not change what the editor produces — it still emits `<del>`.

# Tests

- `HtmlToSpansParserTest.testStrikethroughTagVariants` — `<del>`, `<s>` and `<strike>` each produce a `StrikethroughSpan` over their own text. Fails on `s` and `strike` before the change.
- `HtmlToSpansParserTest.testStrikethroughTagVariantsNestedInOtherTags` — `<s>` inside a `<p>`, asserting the text survives as well as the span. The sanitiser previously discarded the tag, and the span parser's fallback branch does not recurse into unknown tags, so this guards the text itself and not only its styling.
- `parse.rs::parse_s_and_strike_tags_as_strikethrough` — both tags parse and serialise as `<del>`. Fails with `HtmlParseError { parse_errors: ["Node `s` is not supported"] }` before the change.
- `parse.rs::parse_s_tag_nested_in_another_tag` — the same nested inside `<b>`.
- `parse.rs::parse_del_tag` — `<del>` still round-trips untouched.

Verified locally: `cargo test -p wysiwyg` (1077 passing), `cargo fmt -- --check`, `cargo clippy --all-features -- -D warnings`, `cargo check --target wasm32-unknown-unknown -p wysiwyg --no-default-features --features js`, and `:library:testDebugUnitTest --tests "*HtmlToSpansParserTest"` (18 passing).

What these do not prove: the Android tests assert on spans rather than rendered pixels, and the iOS side is untested here — it shares the Rust parser but has no equivalent test added.
