### PR TITLE
Render heading tags as their own bold block

### DIFF
--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToDomParser.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToDomParser.kt
@@ -15,7 +15,7 @@ object HtmlToDomParser {
     private val safeList = Safelist()
         .addTags(
             "a", "b", "strong", "i", "em", "u", "del", "code", "ul", "ol", "li", "pre",
-            "blockquote", "p", "br"
+            "blockquote", "p", "br", "h1", "h2", "h3", "h4", "h5", "h6"
         )
         .addAttributes("a", "href", "data-mention-type", "contenteditable")
         .addAttributes("ol", "start")

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToDomParser.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToDomParser.kt
@@ -14,8 +14,8 @@ object HtmlToDomParser {
 
     private val safeList = Safelist()
         .addTags(
-            "a", "b", "strong", "i", "em", "u", "del", "code", "ul", "ol", "li", "pre",
-            "blockquote", "p", "br", "h1", "h2", "h3", "h4", "h5", "h6", "details", 
+            "a", "b", "strong", "i", "em", "u", "del", "s", "strike", "code", "ul", "ol", "li",
+            "pre", "blockquote", "p", "br", "h1", "h2", "h3", "h4", "h5", "h6", "details",
             "summary",
         )
         .addAttributes("a", "href", "data-mention-type", "contenteditable")

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToSpansParser.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToSpansParser.kt
@@ -91,6 +91,7 @@ internal class HtmlToSpansParser(
             "pre" -> parseCodeBlock(element)
             "blockquote" -> parseQuote(element)
             "p" -> parseParagraph(element)
+            "h1", "h2", "h3", "h4", "h5", "h6" -> parseHeading(element)
             "br" -> parseLineBreak(element)
             else -> if (LoggingConfig.enableDebugLogs) {
                 Timber.d("Unsupported tag: ${element.tagName()}")
@@ -152,6 +153,15 @@ internal class HtmlToSpansParser(
         val start = this.length
         parseChildren(element)
         handleNbspInBlock(element, start, length)
+    }
+
+    private fun SpannableStringBuilder.parseHeading(element: Element) {
+        addLeadingLineBreakForBlockNode(element)
+        val start = this.length
+        inSpans(StyleSpan(Typeface.BOLD)) {
+            parseChildren(element)
+            handleNbspInBlock(element, start, length)
+        }
     }
 
     private fun SpannableStringBuilder.parseQuote(element: Element) {

--- a/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/utils/HtmlToSpansParserTest.kt
+++ b/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/utils/HtmlToSpansParserTest.kt
@@ -161,6 +161,44 @@ class HtmlToSpansParserTest {
     }
 
     @Test
+    fun testHeadings() {
+        val html = "<h1>One</h1><h2>Two</h2><h3>Three</h3><h4>Four</h4><h5>Five</h5><h6>Six</h6>"
+        val spanned = convertHtml(html)
+        assertThat(
+            spanned.dumpSpans().joinToString(",\n"), equalTo(
+                """
+                    One: android.text.style.StyleSpan (0-3) fl=#17,
+                    Two: android.text.style.StyleSpan (4-7) fl=#17,
+                    Three: android.text.style.StyleSpan (8-13) fl=#17,
+                    Four: android.text.style.StyleSpan (14-18) fl=#17,
+                    Five: android.text.style.StyleSpan (19-23) fl=#17,
+                    Six: android.text.style.StyleSpan (24-27) fl=#17
+                """.trimIndent()
+            )
+        )
+        assertThat(
+            spanned.toString(), equalTo("One\nTwo\nThree\nFour\nFive\nSix")
+        )
+    }
+
+    @Test
+    fun testHeadingFollowedByTextKeepsItsOwnLine() {
+        val html = """<h4><a href="https://element.io">Title</a></h4>submitted by someone"""
+        val spanned = convertHtml(html, isEditor = false)
+        assertThat(
+            spanned.dumpSpans().joinToString(",\n"), equalTo(
+                """
+                    Title: io.element.android.wysiwyg.view.spans.LinkSpan (0-5) fl=#17,
+                    Title: android.text.style.StyleSpan (0-5) fl=#17
+                """.trimIndent()
+            )
+        )
+        assertThat(
+            spanned.toString(), equalTo("Title\nsubmitted by someone")
+        )
+    }
+
+    @Test
     fun testEmptyParagraphs() {
         val html = "<p></p><p></p>"
         val spanned = convertHtml(html)


### PR DESCRIPTION
# Issue

`HtmlToDomParser`'s safelist allows no heading tag, so jsoup unwraps `<h1>`–`<h6>` before
`HtmlToSpansParser` ever sees them, and the heading text is merged into whatever follows. A bridged
message such as `<h4>Title</h4>submitted by someone` renders as one unbroken run of text.

Reported downstream as element-hq/element-x-android#2870 (Reddit and RSS bridge messages). This is
the library-side fix suggested in the review of element-hq/element-x-android#7358.

| Before | After |
| :--- | :--- |
| <img width="1078" alt="before" src="https://github.com/user-attachments/assets/fa1cb802-5631-491b-938b-81191da6f05f" /> | <img width="1078" alt="after" src="https://github.com/user-attachments/assets/78c4eef8-d871-4c3f-af04-16ce4a42ff8c" /> |

Those two are from the downstream prototype, which rewrote each heading to `<p><b>…</b></p>` before
sanitising. That produces the same spans and the same block break as this change, so the rendering
is what you get here.

# Fix

Allow the heading tags in the safelist, and give `parseElement` a heading branch. Both are needed
together: adding the tags to the safelist alone would lose the text outright, because the parser's
default branch returns without visiting the children.

A heading is then parsed like a paragraph wrapped in a bold span, so it picks up the same leading
block break as `<p>` and reads as emphasised. `Element.isBlockElement()` already listed `h1`–`h6`.

# Notes

- Headings are approximated as bold body text rather than scaled type, because `StyleConfig` has no
  heading entry and adding one is an API change plus a design decision. For reference, the iOS
  parser in this repository scales `h1`–`h3` to `1.2em` on top of the DTCoreText default bold. Happy
  to add a `HeadingStyleConfig` if you would prefer that.
- `<div>` is left alone; it is a separate spacing question and would widen the change.
- Element X Android keeps its own copy of the safelist in `ToHtmlDocument.kt` and calls
  `fromDocumentToSpans`, so it needs the same six tags added there once this is released.

# Tests

`HtmlToSpansParserTest`:

- `testHeadings` — `<h1>` through `<h6>` each get a bold span and their own line. This is the guard
  against the parse-children trap above.
- `testHeadingFollowedByTextKeepsItsOwnLine` — the reported shape, with a link inside the heading,
  yields `Title\nsubmitted by someone` and keeps the `LinkSpan`.

Both fail on `main`. `./gradlew :library:testDebugUnitTest :library-compose:testDebugUnitTest`
passes: 96 tests, no failures.
