### PR TITLE
Fix text loss and incorrect rendering of received message HTML

### DIFF
--- a/crates/wysiwyg/src/dom/parser/parse.rs
+++ b/crates/wysiwyg/src/dom/parser/parse.rs
@@ -707,6 +707,15 @@ mod sys {
         }
 
         #[test]
+        fn parse_text_wrapped_over_several_lines() {
+            // A line wrapped by the sender collapses to a single space, and no
+            // character on either side of the newline may be lost
+            let dom: Dom<Utf16String> =
+                HtmlParser::default().parse("<p>glass\nhouse</p>").unwrap();
+            assert_eq!(dom.to_html().to_string(), "<p>glass house</p>");
+        }
+
+        #[test]
         fn parse_nested_tags() {
             assert_that!("<b><em>ZZ</em></b>").roundtrips();
             assert_that!("X<b>Y<em>ZZ</em>0</b>1").roundtrips();
@@ -1529,7 +1538,7 @@ fn convert_text<S: UnicodeString>(
         let contents = &surrounding_indent.replace_all(contents, "");
 
         // Replace any internal indentation with a single space
-        let internal_indent = Regex::new(r"s*\n\s*").unwrap();
+        let internal_indent = Regex::new(r"\s*\n\s*").unwrap();
         let contents = &internal_indent.replace_all(contents, " ");
 
         for (i, part) in contents.split("@room").enumerate() {

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToDomParser.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToDomParser.kt
@@ -15,7 +15,7 @@ object HtmlToDomParser {
     private val safeList = Safelist()
         .addTags(
             "a", "b", "strong", "i", "em", "u", "del", "code", "ul", "ol", "li", "pre",
-            "blockquote", "p", "br"
+            "blockquote", "p", "br", "div", "details", "summary"
         )
         .addAttributes("a", "href", "data-mention-type", "contenteditable")
         .addAttributes("ol", "start")

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToSpansParser.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToSpansParser.kt
@@ -90,7 +90,9 @@ internal class HtmlToSpansParser(
             "li" -> parseListItem(element)
             "pre" -> parseCodeBlock(element)
             "blockquote" -> parseQuote(element)
-            "p" -> parseParagraph(element)
+            "p", "div" -> parseParagraph(element)
+            "details" -> parseDetails(element)
+            "summary" -> parseSummary(element)
             "br" -> parseLineBreak(element)
             else -> if (LoggingConfig.enableDebugLogs) {
                 Timber.d("Unsupported tag: ${element.tagName()}")
@@ -154,6 +156,27 @@ internal class HtmlToSpansParser(
         handleNbspInBlock(element, start, length)
     }
 
+    private fun SpannableStringBuilder.parseDetails(element: Element) {
+        addLeadingLineBreakForBlockNode(element)
+        val start = this.length
+        parseChildren(element)
+        handleNbspInBlock(element, start, length)
+    }
+
+    /**
+     * The summary of a `details` element is the only part of it that is always visible, so it's
+     * rendered in bold to tell it apart from the contents that follow it. This matches what the
+     * browser default stylesheet does with `summary`.
+     */
+    private fun SpannableStringBuilder.parseSummary(element: Element) {
+        addLeadingLineBreakForBlockNode(element)
+        val start = this.length
+        inSpans(StyleSpan(Typeface.BOLD)) {
+            parseChildren(element)
+            handleNbspInBlock(element, start, length)
+        }
+    }
+
     private fun SpannableStringBuilder.parseQuote(element: Element) {
         addLeadingLineBreakForBlockNode(element)
         val start = this.length
@@ -208,7 +231,10 @@ internal class HtmlToSpansParser(
             "ol" -> {
                 val typeface = Typeface.defaultFromStyle(Typeface.NORMAL)
                 val textSize = 16.dpToPx()
-                val indexInList = listParent.select("li").indexOf(element)
+                // Only direct children count: a `select` here would also match the items of any
+                // nested list and shift the numbering of everything after it.
+                val siblingItems = listParent.children().filter { it.tagName() == "li" }
+                val indexInList = siblingItems.indexOf(element).coerceAtLeast(0)
                 val customOrder = listParent.attr("start").toIntOrNull()
                 val order = if (customOrder != null) {
                     customOrder + indexInList
@@ -464,7 +490,7 @@ internal class HtmlToSpansParser(
      */
     fun Element.isBlockElement(): Boolean {
         return tagName() in listOf(
-            "p", "ul", "ol", "li", "hr", "pre", "blockquote", "div",
+            "p", "ul", "ol", "li", "hr", "pre", "blockquote", "div", "details", "summary",
             "h1", "h2", "h3", "h4", "h5", "h6",
         )
     }

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/view/spans/QuoteSpan.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/view/spans/QuoteSpan.kt
@@ -79,16 +79,17 @@ class QuoteSpan : MetricAffectingSpan, LeadingMarginSpan {
         val right: Int
 
         if (dir > 0) {
-            // Left to right
+            // Left to right: `x` is the leading (left) edge of the line
             left = x + margin
-            right = x + margin + indicatorWidth
+            right = left + indicatorWidth
         } else {
-            // Right to left
-            left = x + margin - c.width - indicatorWidth
-            right = x + margin
+            // Right to left: `x` is the leading (right) edge of the line, so the margin and the
+            // indicator are laid out towards the left instead
+            right = x - margin
+            left = right - indicatorWidth
         }
 
-        rect = Rect(left, top, right, bottom)
+        rect.set(left, top, right, bottom)
         c.drawRect(rect, paint)
     }
 }

--- a/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/utils/HtmlToSpansParserTest.kt
+++ b/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/utils/HtmlToSpansParserTest.kt
@@ -331,6 +331,57 @@ class HtmlToSpansParserTest {
         )
     }
 
+    @Test
+    fun testNestedListDoesNotShiftTheNumberingOfTheOuterList() {
+        val html = "<ol><li>one</li><li>two<ul><li>nested</li></ul></li><li>three</li></ol>"
+        val spanned = convertHtml(html)
+
+        val orders = spanned.getSpans(0, spanned.length, OrderedListSpan::class.java)
+            .associate { spanned.substring(spanned.getSpanStart(it), spanned.getSpanEnd(it)) to it.order }
+        assertThat(orders["one"], equalTo(1))
+        assertThat(orders["two\nnested"], equalTo(2))
+        assertThat(orders["three"], equalTo(3))
+    }
+
+    @Test
+    fun testNestedOrderedListRestartsItsOwnNumbering() {
+        val html = "<ol><li>one<ol><li>nested one</li><li>nested two</li></ol></li><li>two</li></ol>"
+        val spanned = convertHtml(html)
+
+        // Keyed by the text each span covers, since an item's span also covers its nested list
+        val orders = spanned.getSpans(0, spanned.length, OrderedListSpan::class.java)
+            .associate { spanned.substring(spanned.getSpanStart(it), spanned.getSpanEnd(it)) to it.order }
+        assertThat(orders["one\nnested one\nnested two"], equalTo(1))
+        assertThat(orders["two"], equalTo(2))
+        assertThat(orders["nested one"], equalTo(1))
+        assertThat(orders["nested two"], equalTo(2))
+    }
+
+    @Test
+    fun testDivsAreParsedAsBlocks() {
+        val spanned = convertHtml(
+            html = "<div>First</div><div>Second</div>",
+            isEditor = false,
+        )
+
+        assertThat(spanned.toString(), equalTo("First\n\nSecond"))
+    }
+
+    @Test
+    fun testDetailsAndSummaryAreParsedAsBlocks() {
+        val spanned = convertHtml(
+            html = "<details><summary>Title</summary>Hidden body</details>",
+            isEditor = false,
+        )
+
+        assertThat(spanned.toString(), equalTo("Title\nHidden body"))
+        assertThat(
+            spanned.dumpSpans(), equalTo(
+                listOf("Title: android.text.style.StyleSpan (0-5) fl=#17")
+            )
+        )
+    }
+
     private fun convertHtml(
         html: String,
         isEditor: Boolean = true,

--- a/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/view/spans/QuoteSpanTest.kt
+++ b/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/view/spans/QuoteSpanTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2024 New Vector Ltd.
+ * Copyright 2024 The Matrix.org Foundation C.I.C.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE in the repository root for full details.
+ */
+
+package io.element.android.wysiwyg.view.spans
+
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.Rect
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class QuoteSpanTest {
+    @Test
+    fun testIndicatorIsDrawnAfterTheMarginInLeftToRightText() {
+        val rect = drawLeadingMargin(x = 0, dir = 1)
+
+        assertThat(rect.left, equalTo(MARGIN))
+        assertThat(rect.right, equalTo(MARGIN + INDICATOR_WIDTH))
+    }
+
+    @Test
+    fun testIndicatorIsDrawnBeforeTheMarginInRightToLeftText() {
+        val rect = drawLeadingMargin(x = CANVAS_WIDTH, dir = -1)
+
+        assertThat(rect.right, equalTo(CANVAS_WIDTH - MARGIN))
+        assertThat(rect.left, equalTo(CANVAS_WIDTH - MARGIN - INDICATOR_WIDTH))
+    }
+
+    @Test
+    fun testIndicatorHasTheConfiguredWidthInBothDirections() {
+        assertThat(drawLeadingMargin(x = 0, dir = 1).width(), equalTo(INDICATOR_WIDTH))
+        assertThat(drawLeadingMargin(x = CANVAS_WIDTH, dir = -1).width(), equalTo(INDICATOR_WIDTH))
+    }
+
+    private fun drawLeadingMargin(x: Int, dir: Int): Rect {
+        val span = QuoteSpan(
+            indicatorColor = 0xC0A0A0A0.toInt(),
+            indicatorWidth = INDICATOR_WIDTH,
+            indicatorPadding = INDICATOR_PADDING,
+            margin = MARGIN,
+        )
+        val drawnRect = slot<Rect>()
+        val canvas = mockk<Canvas>(relaxed = true) {
+            every { width } returns CANVAS_WIDTH
+            every { drawRect(capture(drawnRect), any()) } returns Unit
+        }
+
+        span.drawLeadingMargin(
+            canvas, Paint(), x, dir, TOP, BASELINE, BOTTOM, "a quote", 0, 7, true, null
+        )
+
+        return drawnRect.captured
+    }
+
+    companion object {
+        private const val CANVAS_WIDTH = 1000
+        private const val MARGIN = 10
+        private const val INDICATOR_WIDTH = 4
+        private const val INDICATOR_PADDING = 6
+        private const val TOP = 0
+        private const val BASELINE = 10
+        private const val BOTTOM = 20
+    }
+}


### PR DESCRIPTION
Several independent defects in the paths that turn a received `formatted_body` into what the user sees. Each has a regression test that fails before the change.

### Text is silently deleted from wrapped lines

The regex that collapses indentation inside a text node is `s*\n\s*` rather than `\s*\n\s*`, so its first atom matches a *literal* `s`. `replace_all` then swallows any run of `s` immediately preceding a newline along with the line break, and `<p>glass\nhouse</p>` parses as `gla house`.

Any pretty-printed or hard-wrapped `formatted_body` hits this on every wrapped line that happens to end in `s`. Because the characters never reach the model, they are also missing if the message is subsequently edited and re-sent. The neighbouring `surrounding_indent` regex on the preceding line is written correctly and shows the intent.

### The quote indicator covers the text in right-to-left paragraphs

In an RTL paragraph `x` is the right edge of the line, so the indicator has to be laid out by subtracting the margin from it. The RTL branch instead computed its left edge as `x + margin - c.width - indicatorWidth`, giving a rect roughly as wide as the whole canvas: the indicator was painted across the entire line and over the quoted text. Fixes #57.

The LTR branch was already correct and is only rewritten to derive `right` from `left` so the two branches are visibly symmetric. The per-draw `Rect` allocation is replaced by `rect.set(...)` on the field that already existed for that purpose, since `drawLeadingMargin` runs on every frame of a scroll.

### `div`, `details` and `summary` are dropped, merging separate blocks into one line

All three are absent from the jsoup safelist, and jsoup's cleaner keeps a disallowed element's children while discarding the element, so the blocks are concatenated with no separator: `<div>a</div><div>b</div>` renders as `ab`. `div` was already listed in `isBlockElement`, and `details`/`summary` are both in the Matrix allowed-tag list. Fixes element-hq/element-x-android#5966.

`summary` is rendered bold because it is the only part of a `details` that is always visible, which is what the browser default stylesheet does. Collapsing and expanding is a view-level feature and is not attempted here.

### A nested list renumbers the list containing it

Ordered list items took their number from `listParent.select("li")`, which is a recursive selector, so every item of a nested list shifted the numbering of the items after it — in `<ol><li>a<li>b<ul><li>x</ul><li>c</ol>` the item `c` was numbered 4. Only direct children are counted now.

### Tests

- `cargo test -p wysiwyg` — 1075 passed, 0 failed
- `./gradlew :library:testDebugUnitTest` — passed, including four new cases in `HtmlToSpansParserTest` and a new `QuoteSpanTest`
