### PR TITLE
Render the summary of a details element on its own line

### DIFF
--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToDomParser.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToDomParser.kt
@@ -15,7 +15,7 @@ object HtmlToDomParser {
     private val safeList = Safelist()
         .addTags(
             "a", "b", "strong", "i", "em", "u", "del", "s", "strike", "code", "ul", "ol", "li",
-            "pre", "blockquote", "p", "br"
+            "pre", "blockquote", "p", "br", "details", "summary"
         )
         .addAttributes("a", "href", "data-mention-type", "contenteditable")
         .addAttributes("ol", "start")

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToSpansParser.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToSpansParser.kt
@@ -91,6 +91,8 @@ internal class HtmlToSpansParser(
             "pre" -> parseCodeBlock(element)
             "blockquote" -> parseQuote(element)
             "p" -> parseParagraph(element)
+            "details" -> parseDetails(element)
+            "summary" -> parseSummary(element)
             "br" -> parseLineBreak(element)
             else -> if (LoggingConfig.enableDebugLogs) {
                 Timber.d("Unsupported tag: ${element.tagName()}")
@@ -152,6 +154,22 @@ internal class HtmlToSpansParser(
         val start = this.length
         parseChildren(element)
         handleNbspInBlock(element, start, length)
+    }
+
+    private fun SpannableStringBuilder.parseDetails(element: Element) {
+        addLeadingLineBreakForBlockNode(element)
+        val start = this.length
+        parseChildren(element)
+        handleNbspInBlock(element, start, length)
+    }
+
+    private fun SpannableStringBuilder.parseSummary(element: Element) {
+        addLeadingLineBreakForBlockNode(element)
+        val start = this.length
+        inSpans(StyleSpan(Typeface.BOLD)) {
+            parseChildren(element)
+            handleNbspInBlock(element, start, length)
+        }
     }
 
     private fun SpannableStringBuilder.parseQuote(element: Element) {
@@ -464,7 +482,7 @@ internal class HtmlToSpansParser(
      */
     fun Element.isBlockElement(): Boolean {
         return tagName() in listOf(
-            "p", "ul", "ol", "li", "hr", "pre", "blockquote", "div",
+            "p", "ul", "ol", "li", "hr", "pre", "blockquote", "div", "details", "summary",
             "h1", "h2", "h3", "h4", "h5", "h6",
         )
     }

--- a/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/utils/HtmlToSpansParserTest.kt
+++ b/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/utils/HtmlToSpansParserTest.kt
@@ -362,6 +362,31 @@ class HtmlToSpansParserTest {
         )
     }
 
+    @Test
+    fun testDetailsAndSummaryAreParsedAsBlocks() {
+        val spanned = convertHtml(
+            html = "<details><summary>Title</summary>Hidden body</details>",
+            isEditor = false,
+        )
+
+        assertThat(spanned.toString(), equalTo("Title\nHidden body"))
+        assertThat(
+            spanned.dumpSpans(), equalTo(
+                listOf("Title: android.text.style.StyleSpan (0-5) fl=#17")
+            )
+        )
+    }
+
+    @Test
+    fun testDetailsKeepsItsTextAndStartsItsOwnBlock() {
+        val spanned = convertHtml(
+            html = "<p>Before</p><details><summary>Title</summary>Body</details>",
+            isEditor = false,
+        )
+
+        assertThat(spanned.toString(), equalTo("Before\n\nTitle\nBody"))
+    }
+
     private fun convertHtml(
         html: String,
         isEditor: Boolean = true,


### PR DESCRIPTION
# Issue

A message whose `formatted_body` uses `<details>` renders with its summary glued to the body it is
supposed to introduce: `<details><summary>Title</summary>Hidden body</details>` comes out as
`TitleHidden body`, on one line, with nothing to show where the summary ends. Reported downstream as
element-hq/element-x-android#5966.

Both tags are in the Matrix specification's
[suggested set of permitted tags](https://spec.matrix.org/latest/client-server-api/#mroommessage-msgtypes),
so they arrive in ordinary messages, and Element Web renders the summary on a line of its own.

This is the library-side fix suggested in the review of element-hq/element-x-android#7444, which
worked around it in the app instead.

# Fix

`HtmlToDomParser`'s `Safelist` lists neither tag, and jsoup's cleaner keeps a disallowed element's
children while discarding the element, so `HtmlToSpansParser` only ever sees the concatenated text —
there is no block boundary left for it to act on.

Allowing the tags alone would make things worse: `parseElement`'s default branch returns without
visiting the children, so the text would be dropped outright rather than merely run together. Both
tags therefore get a `parseElement` branch as well as a safelist entry, and both join
`isBlockElement` so they pick up the same leading break `<p>` already gets.

`summary` is rendered bold because it is the only part of a `details` that is always visible, which
is what the browser default stylesheet does. Collapsing and expanding is a view-level feature and is
not attempted here.

`<div>` has the same safelist gap but is left alone: it is a separate spacing question, and it is
already part of #149. That PR also carries these two tags among its other fixes — I will drop the
overlap from it so this is the only place they change.

# Tests

- `HtmlToSpansParserTest.testDetailsAndSummaryAreParsedAsBlocks` — the reported shape, asserting the
  line break and the bold span over the summary. Before the change:
  `Expected: "Title\nHidden body" but: was "TitleHidden body"`.
- `HtmlToSpansParserTest.testDetailsKeepsItsTextAndStartsItsOwnBlock` — a `details` after a
  paragraph. This is the guard against the parse-children trap above: the text has to survive, not
  just gain a break. Before the change: `Expected: "Before\n\nTitle\nBody" but: was
  "Before\nTitleBody"`.

`./gradlew :library:testDebugUnitTest :library-compose:testDebugUnitTest` passes: 98 tests, no
failures. Reverting only the two source files leaves exactly these two red and the other 18 in the
class green.

What this does not prove: the assertions are on text and spans rather than rendered pixels, and the
iOS parser in this repository is untouched — it handles HTML separately.
